### PR TITLE
HOTFIX: Fix incompatibility with AP 0.5.1

### DIFF
--- a/worlds/rain_world/__init__.py
+++ b/worlds/rain_world/__init__.py
@@ -94,7 +94,7 @@ class RainWorldWorld(World):
         # PRIORITY PASSAGES
         if num := self.options.passage_priority.value > 0:
             unprioritized_passage_locations = [
-                l for l in self.get_locations()
+                l for l in self.multiworld.get_locations(self.player)
                 if l.name.startswith("Passage-") and l.progress_type == LocationProgressType.DEFAULT
             ]
             for loc in sample(unprioritized_passage_locations, min([num, len(unprioritized_passage_locations)])):


### PR DESCRIPTION
## What is this fixing or adding?
Change call to `World.get_locations()` which is not valid in 0.5.1

## How was this tested?
Packaged and generated a seed on a 0.5.1.Hotfix1 launcher