### PR TITLE
add bypass setting to PPwS

### DIFF
--- a/worlds/rain_world/docs/checks_en.md
+++ b/worlds/rain_world/docs/checks_en.md
@@ -50,8 +50,10 @@ There are several unique checks, mostly associated with the iterators:
 ## Passages
 Completing a passage is a check, and the passage tokens (which allow for fast-travel)
 that they would normally give are placed in the item pool.
-The logical requirement for each passage varies.
-There are four passages that may be earned before The Survivor is earned:
+The logical requirement varies between passages
+and also depends on the `Passage progress without Survivor` setting in the player YAML.
+
+There are four passages that may always be earned before The Survivor is earned, regardless of settings:
 
 | Passage           | Eligibility                                 | Requirements                                                                                 |
 |-------------------|---------------------------------------------|----------------------------------------------------------------------------------------------|
@@ -61,7 +63,7 @@ There are four passages that may be earned before The Survivor is earned:
 | The Survivor      | Any                                         | Max karma at least 5                                                                         |
 
 There are three passages that may be earned before The Survivor,
-but if and only if the `Passage progress without survivor` setting is enabled:
+but only if the `Passage progress without Survivor` setting is either `enabled` or `bypassed`:
 
 | Passage           | Eligibility | Requirements                                                                            |
 |-------------------|-------------|-----------------------------------------------------------------------------------------|
@@ -69,7 +71,8 @@ but if and only if the `Passage progress without survivor` setting is enabled:
 | The Friend        | Any         | Access to one lizard                                                                    |
 | The Wanderer      | Any         | Access to every story region for the given slugcat; each individual pip is also a check |
 
-The remaining seven passages can only be earned after The Survivor has been earned:
+The remaining seven passages require The Survivor unless
+`Passage progress without Survivor` is `bypassed`:
 
 | Passage       | Eligibility                                             | Requirements                                                                                                                         |
 |---------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|

--- a/worlds/rain_world/docs/settings_en.md
+++ b/worlds/rain_world/docs/settings_en.md
@@ -7,13 +7,6 @@ How many extra karma cap items are placed into the pool.
 When set to `0`, there are exactly enough karma items to raise max karma to 10,
 regardless of the selected victory condition.
 
-### Passage progress without Survivor
-`Passage progress without Survivor` (PPwS) is a setting in the Rain World Remix settings
-which affects when The Dragon Slayer, The Friend, and The Wanderer can be earned.
-Enabling PPwS makes it possible to earn these passages without first earning The Survivor.
-
-The Randomizer mod will override the behavior in-game to match your player YAML setting.
-
 ### Victory condition
 The default victory condition, ascension, logically requires raising max karma to 10
 (which requires 8 karma items) and accessing Subterranean (or, for Saint, Rubicon).

--- a/worlds/rain_world/options.py
+++ b/worlds/rain_world/options.py
@@ -6,11 +6,22 @@ from Options import PerGameCommonOptions, Toggle, Range, OptionGroup, Choice, Pr
 
 #################################################################
 # IMPORTANT SETTINGS
-class PassageProgressWithoutSurvivor(Toggle):
-    """Whether The Dragon Slayer, The Friend, and The Wanderer are completable without completing The Survivor.
+class PassageProgressWithoutSurvivor(Choice):
+    """How The Survivor affects earning other passages.
+
+    **Disabled**: Only The Martyr, The Mother, and The Pilgrim can be earned before The Survivor.
+
+    **Enabled**: The Dragon Slayer, The Friend, and The Wanderer can additionally be earned before The Survivor.
+
+    **Bypassed**: Every passage can be earned before The Survivor.
+
     This will override the actual value of the corresponding setting in the Rain World Remix menu."""
     display_name = "Passage progress without Survivor"
-    default = True
+    option_disabled = 0
+    option_enabled = 1
+    option_bypassed = 2
+
+    default = 2
 
 
 class WhichGamestate(Choice):

--- a/worlds/rain_world/regions/abstract.py
+++ b/worlds/rain_world/regions/abstract.py
@@ -20,8 +20,10 @@ def generate(options: RainWorldOptions):
         ConnectionData("Menu", "Food Quest", "Food Quest"),
     ]
 
-    if options.passage_progress_without_survivor:
-        ret.append(ConnectionData("Menu", "PPwS Passages", "Bypass Survivor requirement"))
+    if options.passage_progress_without_survivor in ("enabled", "bypassed"):
+        ret.append(ConnectionData("Menu", "PPwS Passages", "Passage progress without Survivor"))
+    if options.passage_progress_without_survivor == "bypassed":
+        ret.append(ConnectionData("Menu", "Late Passages", "Bypass Survivor requirement"))
 
     return ret
 


### PR DESCRIPTION
Change the PPwS setting to allow for totally bypassing The Survivor as a requirement for other passages.