### PR TITLE
Update echo logic

### DIFF
--- a/worlds/rain_world/__init__.py
+++ b/worlds/rain_world/__init__.py
@@ -161,6 +161,7 @@ class RainWorldWorld(World):
             "checks_tokens_pearls",  # ...whether all tokens should be available.
             "which_victory_condition",  # ...which victory condition is a win.
             "which_gate_behavior",  # ...how gates should behave.
+            "difficulty_echo_low_karma",  # ...how low-karma echo appearances should be handled.
         )
         # ...which room to spawn in.  Empty string for default.
         d["starting_room"] = ("" if self.start_is_default

--- a/worlds/rain_world/docs/checks_en.md
+++ b/worlds/rain_world/docs/checks_en.md
@@ -21,17 +21,30 @@ The `Misc2` pearl in Subterranean, though it appears on the interactive map, is 
 
 ## Echoes
 Visiting an echo is a check, and the karma cap increases they would normally give are placed in the item pool.
-By default, echo apperance follows the same rules as the unrandomized game:
-- Saint can always see echoes, regardless of current and max karma.
-- For other slugcats:
-  - If max karma is 7 or more, current karma must be at least 6.
-  - If max karma is 5, current karma must be 5.
-  - If max karma is less than 5, current karma must be equal to max karma
-  and karma flower reinforcement must be active.
+Whether an echo appears depends on some combination of 
+slugcat, current karma, max karma, whether karma flower reinforcement is active,
+and the `Low-karma echo appearance` player YAML setting:
 
-Note that current karma is not logically constrained,
-so echo checks are considered accessible as soon as max karma reaches 5
-or, for Artificer, as soon as a karma flower is accessible.
+- If max karma >= 7:
+  - Echoes always appear for Saint.
+  - Other slugcats require current karma >= 6.
+- If max karma = 5:
+  - Echoes always appear for Saint.
+  - Other slugcats require current karma = 5.
+- If max karma < 5:
+  - If `Low-karma echo appearance` is `Never`, echoes do not appear.
+  - If `Low-karma echo appearance` is `With Karma Flower`,
+    echoes appear if current karma = max karma *and* karma reinforcement is active.
+  - If `Low-karma echo appearance` is `Without Karma Flower`,
+    echoes appear if current karma = max karma.
+  - If `Low-karma echo appearance` is `Unaltered` (default):
+    - Echoes always appear for Saint.
+    - Artificer requires current karma = max karma *and* karma reinforcement.
+    - Other slugcats require current karma = max karma.
+
+Note that current karma is not logically constrained.
+This means, for instance, that once max karma >= 5,
+all echoes are considered accessible once they are reachable.
 
 ## Unique checks
 There are several unique checks, mostly associated with the iterators:

--- a/worlds/rain_world/docs/checks_en.md
+++ b/worlds/rain_world/docs/checks_en.md
@@ -22,9 +22,11 @@ The `Misc2` pearl in Subterranean, though it appears on the interactive map, is 
 ## Echoes
 Visiting an echo is a check, and the karma cap increases they would normally give are placed in the item pool.
 Whether an echo appears depends on some combination of 
-slugcat, current karma, max karma, whether karma flower reinforcement is active,
+which slugcat is being played, which echo is being met,
+current karma, max karma, whether karma flower reinforcement is active,
 and the `Low-karma echo appearance` player YAML setting:
 
+- The echoes in The Exterior, Subterranean, Metropolis, and Submerged Superstructure (for Saint) always appear.
 - If max karma >= 7:
   - Echoes always appear for Saint.
   - Other slugcats require current karma >= 6.

--- a/worlds/rain_world/locations/__init__.py
+++ b/worlds/rain_world/locations/__init__.py
@@ -6,7 +6,7 @@ from ..options import RainWorldOptions
 # Tokens/Pearls        0 -  999
 # Unique            4900 - 4999
 # Passages          5000 - 5046
-# Echoes            5070 - 5079
+# Echoes            5070 - 5080
 # Food Quest        5250 - 5271
 
 
@@ -15,6 +15,6 @@ def generate(options: RainWorldOptions) -> list[LocationData]:
         *tokens_pearls.generate(options),
         *unique.generate(options),
         *passages.generate(options),
-        *echoes.locations,
+        *echoes.generate(options),
         *foodquest.generate(options),
     ]

--- a/worlds/rain_world/locations/classes.py
+++ b/worlds/rain_world/locations/classes.py
@@ -41,16 +41,11 @@ class LocationData:
 class PhysicalLocation(LocationData):
     def __init__(self, full_name: str, short_name: str, region: str, offset: int, room: str,
                  access_condition: Condition = ConditionBlank,
-                 generation_condition: Callable[[RainWorldOptions], bool] = lambda _: True):
-        super().__init__(full_name, short_name, region, offset, access_condition, generation_condition)
+                 generation_condition: Callable[[RainWorldOptions], bool] = lambda _: True,
+                 access_condition_generator: Optional[Callable[[RainWorldOptions], Condition]] = None):
+        super().__init__(full_name, short_name, region, offset, access_condition, generation_condition,
+                         access_condition_generator=access_condition_generator)
         self.room = room
-
-
-class Echo(PhysicalLocation):
-    def __init__(self, ghost: str, region: str, offset: int, room: str,
-                 access_condition: Condition = ConditionBlank,
-                 generation_condition: Callable[[RainWorldOptions], bool] = lambda _: True):
-        super().__init__(f"Echo-{ghost}", f"Echo-{ghost}", region, offset, room, access_condition, generation_condition)
 
 
 class Passage(LocationData):

--- a/worlds/rain_world/locations/echoes.py
+++ b/worlds/rain_world/locations/echoes.py
@@ -10,8 +10,16 @@ class Echo(PhysicalLocation):
         self.free = free
         
     def make(self, player: int, multiworld: MultiWorld, options: RainWorldOptions) -> bool:
-        if not self.free and options.starting_scug == "Artificer":
-            self.access_condition = AnyOf(Simple("KarmaFlower"), Simple("Karma", 4))
+        if not self.free:
+            match options.difficulty_echo_low_karma:
+                case "never":
+                    self.access_condition = Simple("Karma", 4)
+                case "with_karma_flower":
+                    self.access_condition = AnyOf(Simple("KarmaFlower"), Simple("Karma", 4))
+                case "unaltered":
+                    if options.starting_scug == "Artificer":
+                        self.access_condition = AnyOf(Simple("KarmaFlower"), Simple("Karma", 4))
+
         return super().make(player, multiworld, options)
 
 

--- a/worlds/rain_world/locations/echoes.py
+++ b/worlds/rain_world/locations/echoes.py
@@ -1,19 +1,42 @@
-from .classes import LocationData, Echo
+from BaseClasses import MultiWorld
+from .classes import LocationData, PhysicalLocation
 from ..conditions.classes import Simple, AnyOf
-from ..conditions import generate
+from ..options import RainWorldOptions
 
-cond_normal = AnyOf(Simple("Karma", 4), Simple("KarmaFlower"), Simple("Scug-Saint"))
-cond_no_saint = AnyOf(Simple("Karma", 4), Simple("KarmaFlower"))
 
-locations: list[LocationData] = [
-    Echo("CC", "Chimney Canopy", 5070, "", cond_normal),
-    Echo("SH", "Shaded Citadel", 5071, "", cond_no_saint),
-    Echo("LF", "Farm Arrays", 5072, "", cond_normal),
-    Echo("UW", "The Exterior", 5073, "", cond_no_saint),
-    Echo("SI", "Sky Islands", 5074, "", cond_normal),
-    Echo("SB", "Subterranean ravine", 5075, "", cond_normal),
-    Echo("LC", "Metropolis", 5076, "", Simple("Scug-Artificer")),
-    Echo("UG", "Undergrowth", 5077, "", Simple("Scug-Saint")),
-    Echo("CL", "Silent Construct", 5078, "", Simple("Scug-Saint")),
-    Echo("SL", "Shoreline", 5079, "", Simple("Scug-Saint"), generate.whitelist_scugs(["Saint"], True)),
-]
+class Echo(PhysicalLocation):
+    def __init__(self, ghost: str, region: str, offset: int, room: str, free: bool = False):
+        super().__init__(f"Echo-{ghost}", f"Echo-{ghost}", region, offset, room)
+        self.free = free
+        
+    def make(self, player: int, multiworld: MultiWorld, options: RainWorldOptions) -> bool:
+        if not self.free and options.starting_scug == "Artificer":
+            self.access_condition = AnyOf(Simple("KarmaFlower"), Simple("Karma", 4))
+        return super().make(player, multiworld, options)
+
+
+# Which echoes are "free" is determined by `GhostWorldPresence.SpawnGhost`.
+locations: dict[str, LocationData] = {
+    "CC": Echo("CC", "Chimney Canopy", 5070, ""),
+    "SH": Echo("SH", "Shaded Citadel", 5071, ""),
+    "LF": Echo("LF", "Farm Arrays", 5072, ""),
+    "UW": Echo("UW", "The Exterior", 5073, "", True),
+    "SI": Echo("SI", "Sky Islands", 5074, ""),
+    "SB": Echo("SB", "Subterranean ravine", 5075, "", True),
+    "LC": Echo("LC", "Metropolis", 5076, "", True),
+    "UG": Echo("UG", "Undergrowth", 5077, ""),
+    "CL": Echo("CL", "Silent Construct", 5078, ""),
+    "SL": Echo("SL", "Shoreline", 5079, ""),
+    "MS": Echo("MS", "Submerged Superstructure", 5080, "", True),
+}
+
+
+def generate(options: RainWorldOptions) -> list[LocationData]:
+    match options.starting_scug:
+        case "Saint":
+            keys = ["CC", "LF", "SI", "SB", "UG", "CL", "SL", "MS"]
+        case _:
+            # The LC echo does appear for every scug, but the region doesn't populate except for Artificer.
+            keys = ["CC", "LF", "SI", "SB", "SH", "UW", "LC"]
+
+    return [locations[key] for key in keys]

--- a/worlds/rain_world/options.py
+++ b/worlds/rain_world/options.py
@@ -292,6 +292,27 @@ class DifficultySubmerged(Toggle):
     default = True
 
 
+class DifficultyEchoLowKarma(Choice):
+    """How echo apperances work below 5 max karma.
+    Does not affect the echoes in Subterranean and The Exterior, which can always be visited.
+
+    **Unaltered**: Vanilla behavior.  Artificer needs a karma flower and other slugcats do not.
+
+    **Never**: Echoes cannot appear below 5 karma.
+
+    **With Karma Flower**: Echoes may appear below 5 karma
+    if karma flower reinforcement is active and current karma equals max karma.
+    This is the normal behavior for Artificer.
+
+    **Without Karma Flower**: Echoes may appear if current karma equals max karma."""
+    display_name = "Low-karma echo appearance"
+    option_never = 0
+    option_with_karma_flower = 1
+    option_without_karma_flower = 2
+    option_unaltered = 3
+    default = 3
+
+
 #################################################################
 # FILLER SETTINGS
 class PctTraps(Range):
@@ -601,10 +622,11 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
     difficulty_glow: DifficultyGlow
     difficulty_extreme_threats: DifficultyExtremeThreats
     difficulty_submerged: DifficultySubmerged
+    difficulty_echo_low_karma: DifficultyEchoLowKarma
 
     group_difficulty = [
         ProgressionBalancing, Accessibility, DifficultyMonk, DifficultyHunter, DifficultyOutlaw, DifficultyNomad,
-        DifficultyChieftain, DifficultyGlow, DifficultyExtremeThreats, DifficultySubmerged
+        DifficultyChieftain, DifficultyGlow, DifficultyExtremeThreats, DifficultySubmerged, DifficultyEchoLowKarma,
     ]
 
     #################################################################

--- a/worlds/rain_world/test/test_generic.py
+++ b/worlds/rain_world/test/test_generic.py
@@ -34,7 +34,8 @@ class TestHunterMSC(RainWorldTestBase):
 
 
 class TestHunterMSCShadedCitadel(RainWorldTestBase):
-    options = {"which_gamestate": "hunter_msc", "random_starting_shelter": "shaded_citadel"}
+    options = {"which_gamestate": "hunter_msc", "random_starting_shelter": "shaded_citadel",
+               "difficulty_echo_low_karma": 1}
 
     def test_karma_flower_absence(self):
         self.assertAccessDependency(["Echo-SH"], [["Karma", "Karma", "Karma", "Karma"]], True)


### PR DESCRIPTION
Contingent on SaltiestSyrup/RWRandomizer#38.

- Fixes echo logic assumption that a karma flower is needed below 5 karma (closes #82).
- Adds an option to change how echoes behave at karma caps less than 5 (closes #18).
- Adds the MS echo for Saint which was missing before (the one echo that doesn't count toward The Pilgrim).