### PR TITLE
Add missing gate key

### DIFF
--- a/worlds/rain_world/game_data/general.py
+++ b/worlds/rain_world/game_data/general.py
@@ -53,7 +53,7 @@ story_regions = {
 }
 
 gates_vanilla = {
-    "SU_HI", "SU_DS", "LF_SU", "HI_GW", "HI_CC", "HI_SH", "DS_GW", "GW_SL",
+    "SU_HI", "SU_DS", "LF_SU", "HI_GW", "HI_CC", "HI_SH", "DS_GW", "GW_SL", "DS_SB"
     "SH_SL", "SB_SL", "SH_UW", "CC_UW", "SS_UW", "UW_SS", "SI_CC", "SI_LF", "LF_SB"
 }
 


### PR DESCRIPTION
`GATE_DS_SB` was never considered accessible so its key was never added to the pool for any worldstate.