### PR TITLE
Fix error when starting in VS with glow required for dark places

### DIFF
--- a/worlds/rain_world/game_data/shelters.py
+++ b/worlds/rain_world/game_data/shelters.py
@@ -120,7 +120,5 @@ def get_starts(options: RainWorldOptions) -> list[str]:
         if code == "SB":
             ret.remove("SB_S02")
             ret.remove("SB_S04")
-        elif code == "VS":
-            ret.remove("VS_S03")
 
     return ret


### PR DESCRIPTION
`VS_S03` was marked as invalid start if glow is required for dark places, but it's not in the Expedition start list anyway so this results in an error when VS is the starting region.