### PR TITLE
Passage tweaks

### DIFF
--- a/worlds/rain_world/docs/checks_en.md
+++ b/worlds/rain_world/docs/checks_en.md
@@ -68,38 +68,36 @@ that they would normally give are placed in the item pool.
 The logical requirement for each passage varies.
 There are four passages that may be earned before The Survivor is earned:
 
-| Passage           | Eligibility                                 | Requirements                                                                                 |
-|-------------------|---------------------------------------------|----------------------------------------------------------------------------------------------|
-| The Martyr        | Any; MSC enabled                            | None                                                                                         |
-| The Mother        | Survivor, Hunter, or Gourmand; MSC enabled  | Access to a region which spawns slugpups normally<sup>b</sup>                                |
-| The Pilgrim       | Any; MSC enabled                            | Access to all eligible echoes                                                                |
-| The Survivor      | Any                                         | Max karma at least 5                                                                         |
+| Passage           | Eligibility                                 | Requirements                                    |
+|-------------------|---------------------------------------------|-------------------------------------------------|
+| The Martyr        | Any; MSC enabled                            | None                                            |
+| The Mother        | Survivor, Hunter, or Gourmand; MSC enabled  | Access to HI, DS, GW, SH, CC, SI, LF, SB, or VS |
+| The Pilgrim       | Any; MSC enabled                            | Access to all eligible echoes                   |
+| The Survivor      | Any                                         | Max karma at least 5                            |
 
 There are three passages that may be earned before The Survivor,
 but if and only if the `Passage progress without survivor` setting is enabled:
 
-| Passage           | Eligibility | Requirements                                                                            |
-|-------------------|-------------|-----------------------------------------------------------------------------------------|
-| The Dragon Slayer | Not Saint   | Access to six eligibile lizard types<sup>c</sup>                                        |
-| The Friend        | Any         | Access to one lizard                                                                    |
-| The Wanderer      | Any         | Access to every story region for the given slugcat; each individual pip is also a check |
+| Passage           | Eligibility | Requirements                                                                                                                              |
+|-------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| The Dragon Slayer | Not Saint   | - Vanilla: Access to Blue, Pink, Green, Yellow, Black, and White Lizards<br/>- MSC: Red, Cyan, Strawberry, and Caramel Lizards also count |
+| The Friend        | Any         | Access to one lizard                                                                                                                      |
+| The Wanderer      | Any         | Access to every story region for the given slugcat; each individual pip is also a check                                                   |
 
 The remaining seven passages can only be earned after The Survivor has been earned:
 
 | Passage       | Eligibility                                             | Requirements                                                                                                                         |
 |---------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| The Chieftain | Not Artificer                                           | Access to a Scavenger (or Scavenger Outpost/Toll)<sup>a</sup>                                                                        |
-| The Hunter    | Not Saint                                               | Access to 3<sup>a</sup> types of meat                                                                                                |
-| The Monk      | Any                                                     | Access to 3<sup>a</sup> types of non-meat foods                                                                                      |
-| The Nomad     | Any; MSC enabled                                        | Access to 5<sup>a</sup> different regions                                                                                            |  
-| The Outlaw    | Not Saint                                               | Access to 5<sup>a</sup> eligible creatures                                                                                           |
-| The Saint     | Any                                                     | None                                                                                                                                 |
+| The Chieftain | Not Artificer                                           | Access to a Scavenger (or Scavenger Toll if `The Chieftain requires toll` is set)                                                    |
+| The Hunter    | Not Saint                                               | Access to several types of meat (number depends on `The Hunter difficulty` setting)                                                  |
+| The Monk      | Any                                                     | Access to several types of non-meat foods (number depends on `The Monk difficulty` setting)<sup>a</sup>                              |
+| The Nomad     | Any; MSC enabled                                        | Access to several regions (number depends on `The Nomad difficulty` setting)                                                         |  
+| The Outlaw    | Not Saint                                               | Access to several eligible creatures (number depends on `The Outlaw difficulty` setting)                                             |
+| The Saint     | Any                                                     | None<sup>a</sup>                                                                                                                     |
 | The Scholar   | Not Monk unless MSC is enabled; Not Saint or Sofanthiel | - The Mark of Communication<br/>- Access to three colored pearls<br/>- For Monk, Survivor, and Gourmand: access to Looks to the Moon |
 
-- <sup>a</sup> This is controlled by the player YAML settings.
-- <sup>b</sup> "Normal spawning" of slugpups does not occur in Five Pebbles or Submerged Superstructure.
-- <sup>c</sup> Without MSC, this requires Blue, Pink, Green, Yellow, Black, and White Lizards.
-MSC allows Red, Cyan, Strawberry, and Caramel Lizards to count as well.
+- <sup>a</sup> For Spearmaster, The Monk and The Saint require access to a region with
+at least six popcorn plants (Sky Islands or Farm Arrays). 
 
 ## Food quest
 If MSC is enabled, each item of the food quest is a check when completed.

--- a/worlds/rain_world/docs/checks_en.md
+++ b/worlds/rain_world/docs/checks_en.md
@@ -86,18 +86,15 @@ but if and only if the `Passage progress without survivor` setting is enabled:
 
 The remaining seven passages can only be earned after The Survivor has been earned:
 
-| Passage       | Eligibility                                             | Requirements                                                                                                                         |
-|---------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| The Chieftain | Not Artificer                                           | Access to a Scavenger (or Scavenger Toll if `The Chieftain requires toll` is set)                                                    |
-| The Hunter    | Not Saint                                               | Access to several types of meat (number depends on `The Hunter difficulty` setting)                                                  |
-| The Monk      | Any                                                     | Access to several types of non-meat foods (number depends on `The Monk difficulty` setting)<sup>a</sup>                              |
-| The Nomad     | Any; MSC enabled                                        | Access to several regions (number depends on `The Nomad difficulty` setting)                                                         |  
-| The Outlaw    | Not Saint                                               | Access to several eligible creatures (number depends on `The Outlaw difficulty` setting)                                             |
-| The Saint     | Any                                                     | None<sup>a</sup>                                                                                                                     |
-| The Scholar   | Not Monk unless MSC is enabled; Not Saint or Sofanthiel | - The Mark of Communication<br/>- Access to three colored pearls<br/>- For Monk, Survivor, and Gourmand: access to Looks to the Moon |
-
-- <sup>a</sup> For Spearmaster, The Monk and The Saint require access to a region with
-at least six popcorn plants (Sky Islands or Farm Arrays). 
+| Passage       | Eligibility                                             | Requirements                                                                                                                                                                                |
+|---------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| The Chieftain | Not Artificer                                           | Access to a Scavenger (or Scavenger Toll if `The Chieftain requires toll` is set)                                                                                                           |
+| The Hunter    | Not Saint                                               | Access to several types of meat (number depends on `The Hunter difficulty` setting)                                                                                                         |
+| The Monk      | Any                                                     | - For Hunter, Artificer, and Spearmaster: Access to SI, LF, SS, or DM<br/>- For other slugcats: Access to several types of non-meat foods (number depends on `The Monk difficulty` setting) |
+| The Nomad     | Any; MSC enabled                                        | Access to several regions (number depends on `The Nomad difficulty` setting)                                                                                                                |  
+| The Outlaw    | Not Saint                                               | Access to several eligible creatures (number depends on `The Outlaw difficulty` setting)                                                                                                    |
+| The Saint     | Any                                                     | - For Hunter, Artificer, and Spearmaster: Access to SI, LF, SS, or DM<br/>- For other slugcats: No requirements                                                                             |
+| The Scholar   | Not Monk unless MSC is enabled; Not Saint or Sofanthiel | - The Mark of Communication<br/>- Access to three colored pearls<br/>- For Monk, Survivor, and Gourmand: access to Looks to the Moon                                                        |
 
 ## Food quest
 If MSC is enabled, each item of the food quest is a check when completed.

--- a/worlds/rain_world/game_data/general.py
+++ b/worlds/rain_world/game_data/general.py
@@ -111,7 +111,7 @@ lizards_any = dragonslayer_msc.union({"Salamander", "EelLizard", "TrainLizard"})
 
 echoes_vanilla = ['CC', 'SI', 'LF', 'SB', 'SH', 'UW']
 
-monk_foods_vanilla = ['DangleFruit', 'BubbleFruit', 'SeedCob', 'SlimeMold']
+monk_foods_vanilla = ['DangleFruit', 'BubbleFruit', 'SeedCob', 'SlimeMold', 'SSOracleSwarmer']
 monk_foods_msc = ['LillyPuck', 'GlowWeed', 'DandelionPeach', 'GooieDuck', 'Seed', 'FireEgg']
 
 slugpup_normal_regions = ['HI', 'DS', 'GW', 'SH', 'CC', 'SI', 'LF', 'SB', 'VS']

--- a/worlds/rain_world/game_data/general.py
+++ b/worlds/rain_world/game_data/general.py
@@ -114,7 +114,7 @@ echoes_vanilla = ['CC', 'SI', 'LF', 'SB', 'SH', 'UW']
 monk_foods_vanilla = ['DangleFruit', 'BubbleFruit', 'SeedCob', 'SlimeMold']
 monk_foods_msc = ['LillyPuck', 'GlowWeed', 'DandelionPeach', 'GooieDuck', 'Seed', 'FireEgg']
 
-slugpup_normal_regions = ['SU', 'HI', 'DS', 'SL', 'GW', 'SH', 'UW', 'CC', 'SI', 'LF', 'SB', 'VS', 'OE']
+slugpup_normal_regions = ['HI', 'DS', 'GW', 'SH', 'CC', 'SI', 'LF', 'SB', 'VS']
 
 outlaw_insignificant = ["Fly", "SmallCentipede", "Snail", "PoleMimic", "TubeWorm", "Overseer"]
 

--- a/worlds/rain_world/locations/passages.py
+++ b/worlds/rain_world/locations/passages.py
@@ -43,7 +43,10 @@ cond_friend = Simple(game_data.general.lizards_any, 1)
 # HUNTER
 def generate_cond_hunter(options: RainWorldOptions) -> Condition:
     return AnyOf(
-        Simple(["Scug-Red", "Scug-Artificer", "Scug-Spear", "Scug-Gourmand", "Scug-Inv"], 1),
+        AllOf(
+            Simple(["Scug-Red", "Scug-Artificer", "Scug-Spear", "Scug-Gourmand", "Scug-Inv"], 1),
+            Simple([f"Access-{region}" for region in set(game_data.general.regions_all).difference({"SS", "MS"})], 1)
+        ),
         AllOf(
             Simple(["Scug-Yellow", "Scug-White", "Scug-Rivulet"], 1),
             Simple(
@@ -58,6 +61,11 @@ def generate_cond_hunter(options: RainWorldOptions) -> Condition:
 #################################################################
 # MONK
 def generate_cond_monk(options: RainWorldOptions) -> Condition:
+    if options.starting_scug == "Spear":
+        return AnyOf(
+            Simple(["Access-SI", "Access-LF"], 1),
+            Simple(["Access-HI", "Access-LM", "Access-SB", "Access-GW"], 2)
+        )
     return AnyOf(
         Simple(game_data.general.monk_foods_vanilla, options.difficulty_monk.value),
         AllOf(Simple('MSC'), Simple(game_data.general.monk_foods_msc, options.difficulty_monk.value))
@@ -72,12 +80,14 @@ cond_mother = AllOf(
     Simple([f"Access-{region}" for region in game_data.general.slugpup_normal_regions], 1)
 )
 
+
 #################################################################
 # NOMAD
-cond_nomad = AllOf(
-    Simple("MSC"),
-    Simple([f"Access-{region}" for region in game_data.general.regions_all], 5)
-)
+def generate_cond_nomad(options: RainWorldOptions) -> Condition:
+    return AllOf(
+        Simple("MSC"),
+        Simple([f"Access-{region}" for region in game_data.general.regions_all], options.difficulty_nomad.value)
+    )
 
 
 #################################################################
@@ -189,9 +199,9 @@ locations: dict[str, LocationData] = {
     "Hunter": Passage("Hunter", "Late Passages", 5041, access_condition_generator=generate_cond_hunter),
     "Monk": Passage("Monk", "Late Passages", 5042, access_condition_generator=generate_cond_monk),
     "Outlaw": Passage("Outlaw", "Late Passages", 5043, access_condition_generator=generate_cond_outlaw),
-    "Saint": Passage("Saint", "Late Passages", 5044),
+    "Saint": Passage("Saint", "Late Passages", 5044, access_condition_generator=generate_cond_monk),
     "Scholar": Passage("Scholar", "Late Passages", 5045, cond_scholar),
-    "Nomad": Passage("Nomad", "Late Passages", 5046, cond_nomad),
+    "Nomad": Passage("Nomad", "Late Passages", 5046, access_condition_generator=generate_cond_nomad),
     **{
         f"Wanderer-{i}": LocationData(
             f"Wanderer-{i}", [], 5049 + i, "PPwS Passages", wanderer_pip_factory(i)

--- a/worlds/rain_world/locations/passages.py
+++ b/worlds/rain_world/locations/passages.py
@@ -61,8 +61,8 @@ def generate_cond_hunter(options: RainWorldOptions) -> Condition:
 #################################################################
 # MONK
 def generate_cond_monk(options: RainWorldOptions) -> Condition:
-    if options.starting_scug == "Spear":
-        return Simple(["Access-SI", "Access-LF"], 1)
+    if options.starting_scug in ["Spear", "Artificer", "Red"]:
+        return Simple(["Access-SI", "Access-LF", "Access-SS", "Access-DM"], 1)
     return AnyOf(
         Simple(game_data.general.monk_foods_vanilla, options.difficulty_monk.value),
         AllOf(Simple('MSC'), Simple(game_data.general.monk_foods_msc, options.difficulty_monk.value))

--- a/worlds/rain_world/locations/passages.py
+++ b/worlds/rain_world/locations/passages.py
@@ -62,10 +62,7 @@ def generate_cond_hunter(options: RainWorldOptions) -> Condition:
 # MONK
 def generate_cond_monk(options: RainWorldOptions) -> Condition:
     if options.starting_scug == "Spear":
-        return AnyOf(
-            Simple(["Access-SI", "Access-LF"], 1),
-            Simple(["Access-HI", "Access-LM", "Access-SB", "Access-GW"], 2)
-        )
+        return Simple(["Access-SI", "Access-LF"], 1)
     return AnyOf(
         Simple(game_data.general.monk_foods_vanilla, options.difficulty_monk.value),
         AllOf(Simple('MSC'), Simple(game_data.general.monk_foods_msc, options.difficulty_monk.value))


### PR DESCRIPTION
Closes #109, and includes several logic tweaks:
- The Monk and The Saint now require specifically SI or LF for Spearmaster.
- The Hunter is never considered in logic if the only accessible region is SS or MS.
- The Mother now only considers regions with at least a 20% normal spawn chance.
- The Nomad now actually uses the player YAML setting.