### PR TITLE
Fix effective whitelist regression

### DIFF
--- a/worlds/rain_world/events/world.py
+++ b/worlds/rain_world/events/world.py
@@ -24,11 +24,11 @@ def generate_events_for_one_gamestate(options: RainWorldOptions,
                     if room_data := region_data.get(room, {}):
                         for obj_type, obj_data in room_data.get("objects", {}).items():
                             flag = events.setdefault(obj_type, GameStateFlag(0))
-                            flag[options.dlcstate, POEW(room_data, obj_data, scugs)] = True
+                            flag[options.dlcstate, POEW(room_data, obj_data, set(scugs))] = True
 
                         for crit_type, crit_data in room_data.get("spawners", {}).get("normal", {}).items():
                             flag = events.setdefault(crit_type, GameStateFlag(0))
-                            flag[options.dlcstate, CDEW(room_data, crit_data, scugs)] = True
+                            flag[options.dlcstate, CDEW(room_data, crit_data, set(scugs))] = True
 
                         if room_tags := room_data.get("tags", []):
                             for tagname, eventname in (
@@ -36,7 +36,7 @@ def generate_events_for_one_gamestate(options: RainWorldOptions,
                             ):
                                 if tagname in room_tags:
                                     flag = events.setdefault(eventname, GameStateFlag(0))
-                                    flag[options.dlcstate, REW(room_data, scugs)] = True
+                                    flag[options.dlcstate, REW(room_data, set(scugs))] = True
 
                 for event_type, event_flag in events.items():
                     if options.satisfies(event_flag):

--- a/worlds/rain_world/locations/foodquest.py
+++ b/worlds/rain_world/locations/foodquest.py
@@ -39,6 +39,9 @@ class FoodQuestPip(AbstractLocation):
             return False
         if self.expanded and not options.checks_foodquest_expanded:
             return False
+        # HARDCODE: Sofanthiel's only glow weed is in MS.  The interactive map is wrong.
+        if options.starting_scug == "Inv" and options.checks_submerged < 2 and self.items[0] == "GlowWeed":
+            return False
         return super().pre_generate(player, multiworld, options)
 
 

--- a/worlds/rain_world/utils.py
+++ b/worlds/rain_world/utils.py
@@ -46,12 +46,14 @@ def flounder2(weights: dict[T, float], count: int) -> list[T]:
 
 
 def placed_object_effective_whitelist(room_data: dict, shiny_data: dict, scuglist: set[str]) -> set[str]:
+    maybe_whitelist = shiny_data.get("whitelist", set())
+
     return (
         room_data.get("whitelist", set(scuglist))
         .difference(room_data.get("blacklist", set()))
-        .difference(shiny_data.get("filter", set()))
+        .difference(shiny_data.get("filter", scuglist.difference(maybe_whitelist)))
         .difference(room_data.get("alted", set()))
-        .union(shiny_data.get("whitelist", set()))
+        .union(maybe_whitelist)
         .difference({""})
     )
 


### PR DESCRIPTION
This fixes #116.  13b9bab (#89) caused a regression which made the Sofanthiel-only Dandelion Peaches in Outskirts accessible to other slugcats.

The fix also revealed that Sofanthiel does not have Glow Weed outside of MS, which has also been addressed.