### PR TITLE
Prevent Scavenger token from generating for Hunter

### DIFF
--- a/worlds/rain_world/locations/tokens_pearls.py
+++ b/worlds/rain_world/locations/tokens_pearls.py
@@ -33,6 +33,9 @@ class TokenOrPearl(RoomLocation):
                 return False
         if not options.satisfies(self.generation_flag):
             return False
+        # HARDCODE: This specific token doesn't appear for Hunter - not sure why.
+        if options.starting_scug == "Red" and self.client_name == "Token-Scavenger-GW":
+            return False
         self.region = room_to_region[self.room]
         return super().pre_generate(player, multiworld, options)
 

--- a/worlds/rain_world/test/test_generic.py
+++ b/worlds/rain_world/test/test_generic.py
@@ -27,6 +27,7 @@ class TestHunterMSC(RainWorldTestBase):
     def test_check_generation(self):
         locs = [loc.name for loc in self.multiworld.get_locations(self.player)]
         self.assertNotIn("Garbage Wastes - Pearl - MS", locs)
+        self.assertNotIn("Garbage Wastes - Arena Token - Scavenger", locs)
         self.assertNotIn("Sky Islands - Broadcast - Chatlog_SI0", locs)
         self.assertNotIn("Sky Islands - Broadcast - Chatlog_SI1", locs)
         self.assertIn("Sky Islands - Arena Token - KingVulture", locs)


### PR DESCRIPTION
Fixes #118.  This appears to be something hardcoded - it should actually be there according to the static data, but isn't.