### PR TITLE
Various logic fixes for SL and MS

### DIFF
--- a/worlds/rain_world/game_data/general.py
+++ b/worlds/rain_world/game_data/general.py
@@ -57,7 +57,7 @@ gates_vanilla = {
     "SH_SL", "SB_SL", "SH_UW", "CC_UW", "SS_UW", "UW_SS", "SI_CC", "SI_LF", "LF_SB"
 }
 
-gates_msc_red = gates_vanilla.union({"HI_VS", "GW_SH", "DS_CC", "SL_VS", "SL_MS", "MS_SL", "SI_VS", "SB_VS"})
+gates_msc_red = gates_vanilla.union({"HI_VS", "GW_SH", "DS_CC", "SL_VS", "SL_MS", "MS_SL", "SI_VS", "SB_VS", "UW_SL"})
 
 accessible_gates = {
     "Vanilla": {scug: gates_vanilla for scug in ["Yellow", "White", "Red"]},

--- a/worlds/rain_world/regions/classes.py
+++ b/worlds/rain_world/regions/classes.py
@@ -95,6 +95,9 @@ class PhysicalRegion(RegionData):
             case "SS":
                 return scug not in ("Saint", "Rivulet")
             case "SL":
+                # HARDCODE
+                if self.name == "Shoreline above puppet":
+                    return (scug == "Rivulet" and options.submerged_should_populate) or scug == "Saint"
                 return scug not in ("Artificer", "Spear")
 
         if not options.msc_enabled:

--- a/worlds/rain_world/regions/physical.py
+++ b/worlds/rain_world/regions/physical.py
@@ -33,7 +33,7 @@ def _generate(options: RainWorldOptions) -> list[PhysicalRegion | ConnectionData
                     PhysicalRegion("Submerged Superstructure", "MS", rooms.difference(bitter)),
                     PhysicalRegion("Bitter Aerie", "MS^", bitter),
                     ConnectionData("Submerged Superstructure", "Bitter Aerie", "Rarefaction cell deposit cutscene",
-                                   Simple(["Scug-Rivulet", "Object-EnergyCell"])),
+                                   Simple(["Scug-Rivulet", "Rarefaction Cell"])),
                 ]
 
             case "SB":
@@ -114,17 +114,24 @@ def _generate(options: RainWorldOptions) -> list[PhysicalRegion | ConnectionData
                 if options.starting_scug != "Rivulet":
                     ret += [ConnectionData("Eastern Underhang + The Leg", "Western Underhang", "UW_A05 to UW_C02")]
 
-            # case "GW":
-            #     if "EDGE" in name or name in ("A24", "A25", "S09"):
-            #         return "Garbage Wastes (upper east)"
-            #     elif name in ("C04", "B08", "S04"):
-            #         return "Garbage Wastes (lower east)"
-            #     return "Garbage Wastes"
-            #
-            # case "SL":
-            #     if name in ("EDGE02", "EDGE01", "BRIDGE01", "BRIDGEEND", "S13"):
-            #         return "Shoreline (broken precipice)"
-            #     return "Shoreline"
+            case "SL":
+                broken_precipice = {"GATE_UW_SL[SL]", "SL_BRIDGEEND", "SL_S13", "SL_EDGE01", "SL_EDGE02", "SL_BRIDGE01"}
+                above_moon = {
+                    "SL_MOONTOP", "SL_ROOF04", "SL_ACCSHAFT", "SL_ROOF03", "GATE_SL_MS[SL]", "SL_TEMPLE", "SL_STOP",
+                    "SL_ROOF01", "SL_WALL06"
+                }
+                remainder = rooms.difference(broken_precipice).difference(above_moon)
+
+                ret += [
+                    PhysicalRegion("Shoreline", "SL", remainder),
+                    PhysicalRegion("Broken Precipice", "SL^", broken_precipice),
+                    PhysicalRegion("Shoreline above puppet", "SL^2", above_moon),
+
+                    ConnectionData("Shoreline above puppet", "Shoreline", "Enter puppet room")
+                ]
+
+                if options.starting_scug == "Saint":
+                    ret += [ConnectionData("Shoreline", "Shoreline above puppet", "Exit top of puppet room")]
 
             case _:
                 ret.append(PhysicalRegion(region_code_to_name[region], region, rooms))


### PR DESCRIPTION
Fixes #119.

- `GATE_UW_SL` is now considered accessible in all MSC states.
- Broken Precipice and Shoreline above the puppet room are now correctly considered their own subregions.
- Bitter Aerie is correctly accessible for Rivulet again.