### PR TITLE
Fix UT receiving blank starting room

### DIFF
--- a/worlds/rain_world/__init__.py
+++ b/worlds/rain_world/__init__.py
@@ -5,7 +5,7 @@ from typing import Mapping, Any
 from Options import OptionError
 from worlds.AutoWorld import World, WebWorld
 from BaseClasses import Tutorial, LocationProgressType
-from .game_data.shelters import get_starts, ingame_capitalization
+from .game_data.shelters import get_starts, ingame_capitalization, get_default_start
 from .options import RainWorldOptions
 from .conditions.classes import Simple
 from .game_data.general import region_code_to_name, story_regions, passage_proper_names
@@ -99,6 +99,8 @@ class RainWorldWorld(World):
 
     def connect_starting_region(self, room: str):
         if not self.start_is_connected:
+            if room == "":
+                room = get_default_start(self.options.starting_scug)
             start = self.multiworld.get_region(room_to_region[room], self.player)
             self.multiworld.get_region('Menu', self.player).connect(start, "Starting region")
             self.start_is_connected = True

--- a/worlds/rain_world/game_data/shelters.py
+++ b/worlds/rain_world/game_data/shelters.py
@@ -59,27 +59,31 @@ ingame_capitalization = {
 }
 
 
+def get_default_start(scug: str) -> str:
+    if scug == "Spear":
+        return "GATE_OE_SU[SU]"
+    elif scug == "Gourmand":
+        return "SH_GOR02"
+    elif scug == "Artificer":
+        return "GW_A24"
+    elif scug == "Rivulet":
+        return "DS_RIVSTART"
+    elif scug == "Saint":
+        return "SI_SAINTINTRO"
+    elif scug == "Red":
+        return "LF_E04"
+    elif scug == "Inv":
+        return "SH_E03"
+    else:
+        return "SU_C04"
+
+
 def get_starts(options: RainWorldOptions) -> list[str]:
     code, name = options.random_starting_region.code, options.random_starting_region.name
     scug, scug_name = options.starting_scug, options.which_campaign.scug_name
 
     if code == "!!!":
-        if scug == "Spear":
-            return ["GATE_OE_SU[SU]"]
-        elif scug == "Gourmand":
-            return ["SH_GOR02"]
-        elif scug == "Artificer":
-            return ["GW_A24"]
-        elif scug == "Rivulet":
-            return ["DS_RIVSTART"]
-        elif scug == "Saint":
-            return ["SI_SAINTINTRO"]
-        elif scug == "Red":
-            return ["LF_E04"]
-        elif scug == "Inv":
-            return ["SH_E03"]
-        else:
-            return ["SU_C04"]
+        return [get_default_start(scug)]
 
     code = alternate_regions.get(code, {}).get(scug, code)
 


### PR DESCRIPTION
Client expects blank `starting_room` to indicate default, but UT fakegen doesn't.  Closes #140.