### PR TITLE
Fix incorrect logic for scholar passage

### DIFF
--- a/worlds/rain_world/locations/passages.py
+++ b/worlds/rain_world/locations/passages.py
@@ -118,9 +118,8 @@ cond_scholar = AnyOf(
         Simple(["Scug-White", "Scug-Gourmand"], 1),
         Simple(["Access-SL", "The Mark"])
     ),
-    Simple(["Scug-Red", "Scug-Rivulet"], 1),
     AllOf(
-        Simple(["Scug-Artificer", "Scug-Spear"], 1),
+        Simple(["Scug-Artificer", "Scug-Spear", "Scug-Red", "Scug-Rivulet"], 1),
         Simple("The Mark")
     ),
 )


### PR DESCRIPTION
Scholar passage had no Mark requirement for Hunter and Rivulet, which it should since the Mark is not given to them at the start of the game in rando
