### PR TITLE
Fix a couple things using old passage location names

### DIFF
--- a/worlds/rain_world/__init__.py
+++ b/worlds/rain_world/__init__.py
@@ -89,7 +89,7 @@ class RainWorldWorld(World):
         if num := self.options.passage_priority.value > 0:
             unprioritized_passage_locations = [
                 l for l in self.multiworld.get_locations(self.player)
-                if l.name.startswith("Passage-") and l.progress_type == LocationProgressType.DEFAULT
+                if l.name.startswith("Passage - ") and l.progress_type == LocationProgressType.DEFAULT
             ]
             for loc in self.random.sample(unprioritized_passage_locations,
                                           min([num, len(unprioritized_passage_locations)])):

--- a/worlds/rain_world/regions/abstract.py
+++ b/worlds/rain_world/regions/abstract.py
@@ -15,7 +15,8 @@ def generate(options: RainWorldOptions):
 
         ConnectionData("Menu", "Events", "Unique event checks"),
         ConnectionData("Menu", "Early Passages", "Early Passages"),
-        ConnectionData("Early Passages", "Late Passages", "Late Passages", Simple("Passage-Survivor", locations=True)),
+        ConnectionData("Early Passages", "Late Passages", "Late Passages",
+                       Simple("Passage - The Survivor", locations=True)),
         ConnectionData("Late Passages", "PPwS Passages", "PPwS Passages"),
         ConnectionData("Menu", "Food Quest", "Food Quest"),
     ]


### PR DESCRIPTION
PPwS and priority passage settings were looking for old passage location names from before #112.  The former has been a generation failure or `enabled` or `disabled` since then and the latter has had no effect at all.