### PR TITLE
Fix generation failures when `checks_submerged` is disabled for Rivulet

### DIFF
--- a/worlds/rain_world/locations/classes.py
+++ b/worlds/rain_world/locations/classes.py
@@ -68,6 +68,11 @@ class RoomLocation(LocationData):
 
     def pre_generate(self, player: int, multiworld: MultiWorld, options: RainWorldOptions) -> bool:
         self.region = room_to_region[self.room]
+
+        if not options.submerged_should_populate:
+            if self.region in ("Submerged Superstructure", "Bitter Aerie", "Shoreline above puppet room"):
+                return False
+
         return super().pre_generate(player, multiworld, options)
 
 

--- a/worlds/rain_world/regions/classes.py
+++ b/worlds/rain_world/regions/classes.py
@@ -104,7 +104,7 @@ class PhysicalRegion(RegionData):
             case "SL":
                 # HARDCODE
                 if self.name == "Shoreline above puppet":
-                    return (scug == "Rivulet" and options.submerged_should_populate) or scug == "Saint"
+                    return scug in ("Rivulet", "Saint")
                 return scug not in ("Artificer", "Spear")
 
         if not options.msc_enabled:
@@ -126,8 +126,6 @@ class PhysicalRegion(RegionData):
             case "UG" | "HR" | "CL":
                 return scug == "Saint"
             case "MS":
-                if not options.submerged_should_populate:
-                    return False
                 # HARDCODE
                 if self.name == "Bitter Aerie":
                     return scug == "Rivulet"


### PR DESCRIPTION
Closes #208.  Fixes the generation failure with this player YAML for seed `605595035`:
```
description: Rain World Template, generated with https://github.com/Eijebong/Archipelago-fuzzer
game: Rain World
requires:
  version: 0.6.1
Rain World:
  which_game_version: '1_10'
  is_msc_enabled: 'true'
  is_watcher_enabled: 'true'
  which_campaign: riv
  passage_progress_without_survivor: bypassed
  which_victory_condition: alternate
  which_gate_behavior: key_only
  death_link: 'true'
  random_starting_region: farm_arrays
  progression_balancing: 28
  accessibility: full
  difficulty_monk: 2
  difficulty_hunter: 1
  difficulty_outlaw: 6
  difficulty_nomad: 6
  difficulty_chieftain: 'true'
  difficulty_glow: 'true'
  difficulty_extreme_threats: 'false'
  difficulty_submerged: 'true'
  difficulty_echo_low_karma: never
  checks_foodquest: all_slugcats
  checks_foodquest_expanded: 'true'
  passage_priority: 6
  checks_devtokens: 'false'
  checks_sheltersanity: 'false'
  checks_submerged: 'false'
  checks_flowersanity: 'true'
  extra_karma_cap_increases: 3
  pct_traps: 21
  weight_jitter: 75
  wt_rocks: 76
  wt_spears: 8
  wt_explosive_spears: 55
  wt_grenades: 51
  wt_flashbangs: 89
  wt_sporepuffs: 28
  wt_cherrybombs: 56
  wt_lanterns: 43
  wt_vulture_masks: 53
  wt_fruit: 32
  wt_bubblefruit: 20
  wt_eggbugeggs: 51
  wt_jellyfish: 8
  wt_mushrooms: 70
  wt_slimemold: 31
  wt_karma_flowers: 68
  wt_lilypucks: 100
  wt_electric_spears: 83
  wt_singularity_bombs: 40
  wt_joke_rifles: 76
  wt_fireeggs: 51
  wt_glowweed: 31
  wt_stuns: 19
  wt_zoomies: 64
  wt_timers: 59
  wt_alarms: 29
  wt_gravity: 71
  wt_rains: 74
  wt_redlizard: 22
  wt_redcentipede: 30
  wt_spitterspider: 9
  wt_brotherlonglegs: 92
  wt_daddylonglegs: 36
  local_items: []
  non_local_items: []
  start_inventory: {}
  start_hints: []
  start_location_hints: []
  exclude_locations: []
  priority_locations: []
  item_links: []
```

Also fixes a related generation failure which occurs for this YAML with seed `945168763`:
```
description: Rain World Template, generated with https://github.com/Eijebong/Archipelago-fuzzer
game: Rain World
Rain World:
  which_game_version: '1_10_1'
  is_msc_enabled: 'true'
  is_watcher_enabled: 'false'
  which_campaign: rivulet
  passage_progress_without_survivor: bypassed
  which_victory_condition: ascension
  which_gate_behavior: karma_only
  death_link: 'false'
  random_starting_region: the_exterior
  progression_balancing: 90
  accessibility: locations
  difficulty_monk: 4
  difficulty_hunter: 4
  difficulty_outlaw: 1
  difficulty_nomad: 4
  difficulty_chieftain: 'true'
  difficulty_glow: 'true'
  difficulty_extreme_threats: 'false'
  difficulty_submerged: 'true'
  difficulty_echo_low_karma: with_karma_flower
  checks_foodquest: 'false'
  checks_foodquest_expanded: 'false'
  passage_priority: 1
  checks_devtokens: 'false'
  checks_sheltersanity: 'true'
  checks_submerged: 'false'
  checks_flowersanity: 'false'
  extra_karma_cap_increases: 30
  pct_traps: 1
  weight_jitter: 23
  wt_rocks: 2
  wt_spears: 35
  wt_explosive_spears: 23
  wt_grenades: 91
  wt_flashbangs: 3
  wt_sporepuffs: 44
  wt_cherrybombs: 51
  wt_lanterns: 52
  wt_vulture_masks: 32
  wt_fruit: 48
  wt_bubblefruit: 2
  wt_eggbugeggs: 84
  wt_jellyfish: 0
  wt_mushrooms: 26
  wt_slimemold: 84
  wt_karma_flowers: 76
  wt_lilypucks: 35
  wt_electric_spears: 80
  wt_singularity_bombs: 69
  wt_joke_rifles: 70
  wt_fireeggs: 71
  wt_glowweed: 42
  wt_stuns: 22
  wt_zoomies: 65
  wt_timers: 52
  wt_alarms: 99
  wt_gravity: 73
  wt_rains: 71
  wt_redlizard: 17
  wt_redcentipede: 22
  wt_spitterspider: 65
  wt_brotherlonglegs: 6
  wt_daddylonglegs: 76
  local_items: []
  non_local_items: []
  start_inventory: {}
  start_hints: []
  start_location_hints: []
  exclude_locations: []
  priority_locations: []
  item_links: []
```