### PR TITLE
Prevent items and locations from having the same names as groups

### DIFF
--- a/worlds/rain_world/items.py
+++ b/worlds/rain_world/items.py
@@ -181,5 +181,5 @@ item_name_to_id: Dict[str, int] = {k: v.code for k, v in all_items.items()}
 
 item_hints: dict[str, set[str]] = {}
 for item in all_items.values():
-    for hint in item.hints:
+    for hint in [h for h in item.hints if h != item.name]:
         item_hints.setdefault(hint, set()).update({item.name})

--- a/worlds/rain_world/locations/classes.py
+++ b/worlds/rain_world/locations/classes.py
@@ -32,7 +32,8 @@ class LocationData:
             self.id = offset + FIRST_ID
             location_map[full_name] = self.id
             for alt_name in self.alt_names + [client_name]:
-                location_hints.setdefault(alt_name, set()).update({full_name})
+                if alt_name != full_name:
+                    location_hints.setdefault(alt_name, set()).update({full_name})
             location_client_map[client_name] = self.full_name
 
     def make(self, player: int, multiworld: MultiWorld, options: RainWorldOptions) -> bool:

--- a/worlds/rain_world/regions/gates.py
+++ b/worlds/rain_world/regions/gates.py
@@ -82,6 +82,10 @@ class GateData:
             right_alt = region_code_to_name[alt]
             ret += [f'Gate: {left_name} to {right_alt}', f'Gate: {right_alt} to {left_name}']
 
+        # HARDCODE: gross bandaid fix for item group name collision with GATE_SL_CL
+        if self.name == "GATE_SH_SL":
+            ret = [r for r in ret if "Silent Construct" not in r]
+
         return ret + [self.name]
 
     def is_accessible(self, options: RainWorldOptions):


### PR DESCRIPTION
Closes #212.  Most of this is just to satisfy general AP unit tests (specifically, `test.general.test_items.TestBase.test_item_name_group_conflict` and `test.general.test_locations.TestBase.test_location_group`), since most collisions were just groups referring to the item of the same name.  However, `Gate: Shoreline to Silent Construct` was actually referring to `GATE_SH_SL`, so that `!hint` command actually would have failed to hint the expected `GATE_SL_CL`.