### PR TITLE
Prevent `SU_S05` from being picked as start for most scugs

### DIFF
--- a/worlds/rain_world/game_data/shelters.py
+++ b/worlds/rain_world/game_data/shelters.py
@@ -120,7 +120,7 @@ def get_starts(options: RainWorldOptions) -> list[str]:
     ret = list(start_shelters[code])
 
     # shelter does not exist in vanilla
-    if code == "SU" and not options.msc_enabled:
+    if code == "SU" and ((not options.msc_enabled) or scug not in ("Yellow", "White", "Gourmand")):
         ret.remove("SU_S05")
 
     # going backwards through puppet room not in logic


### PR DESCRIPTION
While there's technically nothing wrong with starting in `SU_S05` (the shelter closest to Spearmaster's default spawn) as, say, Rivulet, some changes made by #217 / #219 make starting here fail.  At least for now, only Monk, Survivor, and Gourmand are allowed to start in this shelter.