### PR TITLE
Extra logic features for Inv

### DIFF
--- a/worlds/rain_world/regions/physical.py
+++ b/worlds/rain_world/regions/physical.py
@@ -106,31 +106,40 @@ def _generate(options: RainWorldOptions) -> list[PhysicalRegion | ConnectionData
                 ]
 
             case "UW":
+                wall = {
+                    "UW_D01", "UW_A01", "UW_J01", "UW_A02", "UW_E01", "UW_A13", "UW_S03", "UW_F01", "UW_A12",
+                    "GATE_UW_LC[UW]", "UW_A14", "UW_H01", "UW_C07", "GATE_SS_UW[UW]"
+                }
                 west_underhang = {"UW_C04", "UW_D05", "UW_A04", "UW_C02", "UW_C02RIV", "UW_D05RIV", "UW_A04RIV"}
                 east_underhang_and_leg = {
-                    "UW_A05", "UW_C01", "UW_A03", "UW_A10", "UW_J01", "UW_I01", "UW_C08", "GATE_UW_SS[UW]", "UW_A11",
+                    "UW_A05", "UW_C01", "UW_A03", "UW_A10", "UW_J02", "UW_I01", "UW_C08", "GATE_UW_SS[UW]", "UW_A11",
                     "UW_S02", "UW_A06", "UW_E04", "UW_A08", "UW_C03", "UW_D04", "UW_B01", "UW_S07", "UW_PREGATE",
                     "GATE_UW_SL[UW]", "UW_D03", "UW_E03", "UW_A09", "UW_S06", "UW_C06", "UW_E02", "UW_A07", "UW_D02",
                     "UW_S05", "GATE_SH_UW[UW]",
                     "UW_A05RIV", "UW_C01RIV", "UW_A11RIV", "UW_J02RIV", "UW_A06RIV", "UW_E04RIV"
                 }
-                remainder = rooms.difference(west_underhang).difference(east_underhang_and_leg)
+                remainder = rooms.difference(wall).difference(west_underhang).difference(east_underhang_and_leg)
 
                 ret += [
                     PhysicalRegion("The Exterior", "UW", remainder),
                     PhysicalRegion("Western Underhang", "UW^", west_underhang),
                     PhysicalRegion("Eastern Underhang + The Leg", "UW^2", east_underhang_and_leg),
+                    PhysicalRegion("The Wall", "UW^3", wall),
 
                     # Going into Underhang from the west requires a grapple worm.
                     # In Vanilla Survivor and Monk worldstates, there isn't one in D06 (but there is in CC).
                     ConnectionData("The Exterior", "Western Underhang", "UW_D06 to UW_C04", Simple("TubeWorm")),
                     ConnectionData("Western Underhang", "The Exterior", "UW_C04 to UW_D06"),
                     ConnectionData("Western Underhang", "Eastern Underhang + The Leg", "UW_C02 to UW_A05"),
+                    ConnectionData("The Wall", "The Exterior", "UW_D01 to UW_D07")
                 ]
 
                 # Westward through Underhang is not terribly reasonable for Rivulet.
                 if options.starting_scug != "Rivulet":
                     ret += [ConnectionData("Eastern Underhang + The Leg", "Western Underhang", "UW_A05 to UW_C02")]
+                # Inv is not considered able to climb the wall.
+                if options.starting_scug != "Inv":
+                    ret += [ConnectionData("The Exterior", "The Wall", "UW_D07 to UW_D01")]
 
             case "SL":
                 broken_precipice = {"GATE_UW_SL[SL]", "SL_BRIDGEEND", "SL_S13", "SL_EDGE01", "SL_EDGE02", "SL_BRIDGE01"}


### PR DESCRIPTION
Implementing Inv logic suggested on the Discord.

- [x] Inv is no longer expected to climb the wall
- [ ] By default, Inv is not expected to enter UW (and by extension, SS) at all
- [ ] New `difficulty_extreme_regions` option that opens UW for Inv. Can be combined with `difficulty_submerged` to serve as a generic option for difficult regions
- [ ] (Maybe) include Inv DS in extreme regions as well
