### PR TITLE
Make location groups for every region

### DIFF
--- a/worlds/rain_world/locations/classes.py
+++ b/worlds/rain_world/locations/classes.py
@@ -67,6 +67,8 @@ class RoomLocation(LocationData):
         super().__init__(f'{region_name} - {description}',
                          client_name, alt_names + [region_name, full_with_code], offset)
         self.room = room
+        location_hints.setdefault(region_name, set()).update({f'{region_name} - {description}'})
+
 
     def pre_generate(self, player: int, multiworld: MultiWorld, options: RainWorldOptions) -> bool:
         self.region = room_to_region[self.room]


### PR DESCRIPTION
This adds every location that exists physically in a region to groups for each region.

This allows you to potentially exclude (or prioritize) entire regions from logic if you don't (or *really* do) want to deal with a region checks-wise. 
This can potentially be dangerous for generation when excluding a large number of regions, but the `FillError` that results from this abuse is clear enough that a user could quickly find out what went wrong. (Plus for solo games in testing you need to exclude *most* regions to get this error)

The main intention here is to provide an option to 'speed up' a game by lowering the amount of regions that have to be explored. These regions may still have to be traversed, and some locations will still be considered such as food quest and passages.