### PR TITLE
Rework MS options / MS bug fixes

### DIFF
--- a/worlds/rain_world/locations/classes.py
+++ b/worlds/rain_world/locations/classes.py
@@ -73,7 +73,8 @@ class RoomLocation(LocationData):
         self.region = room_to_region[self.room]
 
         if not options.submerged_should_populate:
-            if self.region in ("Submerged Superstructure", "Bitter Aerie", "Shoreline above puppet room"):
+            if self.region in ("Submerged Superstructure", "Bitter Aerie", "Shoreline above puppet room",
+                               "Shoreline near gate to Submerged"):
                 return False
 
         return super().pre_generate(player, multiworld, options)

--- a/worlds/rain_world/locations/foodquest.py
+++ b/worlds/rain_world/locations/foodquest.py
@@ -45,8 +45,8 @@ class FoodQuestPip(AbstractLocation):
             return False
         if self.expanded and not options.checks_foodquest_expanded:
             return False
-        # HARDCODE: Sofanthiel's only glow weed is in MS.  The interactive map is wrong.
-        if options.starting_scug == "Inv" and options.checks_submerged < 2 and self.items[0] == "GlowWeed":
+        # HARDCODE: Sofanthiel and Rivulet's only glow weed are in MS.  The interactive map is wrong.
+        if options.starting_scug in ["Inv", "Rivulet"] and not options.submerged_should_populate and self.items[0] == "GlowWeed":
             return False
         return True
 

--- a/worlds/rain_world/locations/passages.py
+++ b/worlds/rain_world/locations/passages.py
@@ -208,7 +208,7 @@ locations: dict[str, LocationData] = {
 
 
 def generate(options: RainWorldOptions) -> list[LocationData]:
-    keys = ["Survivor", "Friend", "Traveller", "Monk", "Saint"]
+    keys = ["Survivor", "Friend", "Monk", "Saint"]
 
     if options.starting_scug == "Watcher":
         return []
@@ -226,7 +226,11 @@ def generate(options: RainWorldOptions) -> list[LocationData]:
         if options.starting_scug in ["White", "Red", "Gourmand"]:
             keys.append("Mother")
 
-    if options.starting_scug != "Watcher":
-        keys += [f"Wanderer-{i+1}" for i in range(len(wanderer_regions(options.starting_scug, options.msc_enabled)))]
+    # Riv can't get last pip if Submerged inaccessible
+    if options.starting_scug != "Rivulet" or options.submerged_should_populate:
+        keys += [f"Wanderer-{i + 1}" for i in range(len(wanderer_regions(options.starting_scug, options.msc_enabled)))]
+        keys.append("Traveller")
+    else:
+        keys += [f"Wanderer-{i + 1}" for i in range(len(wanderer_regions(options.starting_scug, options.msc_enabled)) - 1)]
 
     return [locations[key] for key in keys]

--- a/worlds/rain_world/options.py
+++ b/worlds/rain_world/options.py
@@ -454,13 +454,18 @@ class ChecksSheltersanity(Toggle):
 
 
 class ChecksSubmerged(Choice):
-    """Whether Submerged Superstructure has any checks."""
+    """Whether Submerged Superstructure has any checks.
+    If only aquatic is chosen, checks will only be generated
+    if playing Rivulet or the Aquatic perk is in the item pool."""
     display_name = "Include Submerged"
     option_all_slugcats = 2
-    option_only_rivulet = 1
+    option_only_aquatic = 1
     option_off = 0
+
     alias_true = 2
     alias_false = 0
+    alias_only_rivulet = 1
+
     default = 1
 
 
@@ -530,14 +535,25 @@ class DifficultyExtremeThreats(Toggle):
     default = 0
 
 
-class DifficultySubmerged(Toggle):
-    """Whether Submerged Superstructure is logically locked behind advancing the story state for Rivulet.
-    Advancing the story state - normally done by removing the rarefaction cell from The Rot -
-    causes the cycle duration to increase significantly, making Submerged Superstructure significantly easier.
+class DifficultySubmerged(Choice):
+    """Changes the logical requirement for entering Submerged Superstructure.
 
-    This setting only impacts Rivulet."""
+    If off, Submerged has no additional requirement to enter.
+
+    If set to aquatic, access to Submerged will expect you to have longer breath time from the Aquatic perk
+    or to be playing as Rivulet. If the Aquatic perk is not in the item pool, this acts the same as "off".
+
+    If set to longer cycles, Rivulet will not be expected to enter Submerged until the Longer Cycles item is obtained."""
     display_name = "Late Submerged"
-    default = True
+    option_longer_cycles = 2
+    option_aquatic = 1
+    option_off = 0
+
+    alias_true = 2
+    alias_false = 0
+    alias_only_rivulet = 2
+
+    default = 1
 
 
 class DifficultyEchoLowKarma(Choice):
@@ -1094,6 +1110,9 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
                 return ("Sphere 1 is too small with these settings.  "
                         f"Do at least one of the following: \n{solution_string}")
 
+        if self.which_victory_condition == 1 and self.starting_scug == "Rivulet" and not self.submerged_should_populate:
+            return f"Rivulet's story ending requires checks in Submerged Superstructure to be enabled."
+
         if self.which_victory_condition == 3:
             if not self.msc_enabled:
                 return (f"Food quest victory condition cannot be selected "
@@ -1107,7 +1126,8 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
     def data_block(self) -> dict: return static_data[self.which_game_version.string][self.dlcstate]
 
     @property
-    def submerged_should_populate(self) -> bool: return self.checks_submerged + (self.starting_scug == "Rivulet") > 1
+    def submerged_should_populate(self) -> bool:
+        return self.checks_submerged + (self.starting_scug == "Rivulet" or "Aquatic Perk" in self.expedition_perks.value) > 1
 
     def get_nontrap_weight_dict(self) -> dict[str, float]:
         ret = {a.item_name: a.value for a in [

--- a/worlds/rain_world/regions/classes.py
+++ b/worlds/rain_world/regions/classes.py
@@ -114,6 +114,8 @@ class PhysicalRegion(RegionData):
                     return scug in ("Rivulet", "Saint")
                 if self.name == "Broken Precipice":
                     return options.msc_enabled and scug not in ("Artificer", "Spear", "Saint")
+                if self.name == "Shoreline near gate to Submerged":
+                    return options.submerged_should_populate and scug not in ("Artificer", "Spear")
                 return scug not in ("Artificer", "Spear")
 
         if not options.msc_enabled:
@@ -138,4 +140,4 @@ class PhysicalRegion(RegionData):
                 # HARDCODE
                 if self.name == "Bitter Aerie":
                     return scug == "Rivulet"
-                return scug not in ("Artificer", "Spear")
+                return options.submerged_should_populate and scug not in ("Artificer", "Spear")

--- a/worlds/rain_world/regions/gates.py
+++ b/worlds/rain_world/regions/gates.py
@@ -117,7 +117,7 @@ class GateData:
                 left = ["Impossible"]
             left += ["The Mark", "Citizen ID Drone"]
 
-        if gg == "MS_SL" and options.starting_scug == "Rivulet" and options.difficulty_submerged:
+        if gg == "MS_SL" and options.starting_scug == "Rivulet" and options.difficulty_submerged == 2:
             left.append("Disconnect_FP")
 
         return Simple(left), Simple(right)

--- a/worlds/rain_world/regions/physical.py
+++ b/worlds/rain_world/regions/physical.py
@@ -144,18 +144,30 @@ def _generate(options: RainWorldOptions) -> list[PhysicalRegion | ConnectionData
                     "SL_MOONTOP", "SL_ROOF04", "SL_ACCSHAFT", "SL_ROOF03", "GATE_SL_MS[SL]", "SL_TEMPLE", "SL_STOP",
                     "SL_ROOF01", "SL_WALL06"
                 }
-                remainder = rooms.difference(broken_precipice).difference(above_moon)
+                near_submerged_gate = {"SL_C15", "SL_WALL02", "SL_WALL05", "SL_S15", "GATE_MS_SL[SL]"}
+                remainder = rooms.difference(broken_precipice).difference(above_moon).difference(near_submerged_gate)
 
                 ret += [
                     PhysicalRegion("Shoreline", "SL", remainder),
                     PhysicalRegion("Broken Precipice", "SL^", broken_precipice),
                     PhysicalRegion("Shoreline above puppet", "SL^2", above_moon),
+                    PhysicalRegion("Shoreline near gate to Submerged", "SL^3", near_submerged_gate),
 
-                    ConnectionData("Shoreline above puppet", "Shoreline", "Enter puppet room")
+                    ConnectionData("Shoreline above puppet", "Shoreline", "Enter puppet room"),
+                    ConnectionData("Shoreline near gate to Submerged", "Shoreline", "Leaving Submerged")
                 ]
 
                 if options.starting_scug == "Saint":
                     ret += [ConnectionData("Shoreline", "Shoreline above puppet", "Exit top of puppet room")]
+
+                # If Submerged has no checks, swimming down towards the gate is not in logic.
+                if options.submerged_should_populate:
+                    if options.difficulty_submerged >= 1 and options.starting_scug != "Rivulet" and "Aquatic" in options.expedition_perks.value:
+                        ret += [ConnectionData("Shoreline", "Shoreline near gate to Submerged",
+                                               "Entering towards Submerged", Simple("Aquatic Perk"))]
+                    else:
+                        ret += [ConnectionData("Shoreline", "Shoreline near gate to Submerged",
+                                               "Entering towards Submerged")]
 
             case "WRFA":
                 western = {"WRFA_S08", "WRFA_C11", "WRFA_A21"}

--- a/worlds/rain_world/test/test_check_options.py
+++ b/worlds/rain_world/test/test_check_options.py
@@ -1,0 +1,29 @@
+from .bases import RainWorldTestBase
+
+if RUN_GENERAL_AP_UNITTESTS := False:
+    # Simply importing this runs the tests.
+    from .bases import RainWorldGeneralTestBase
+
+class TestChecksSubmergedAquatic(RainWorldTestBase):
+    options = {"checks_submerged": "only_aquatic", "is_msc_enabled": True, "expedition_perks": ["Aquatic Perk"]}
+
+    def test_check_generation(self):
+        regions = [region.name for region in self.multiworld.get_regions(self.player)]
+        self.assertIn("Submerged Superstructure", regions)
+        self.assertIn("Shoreline near gate to Submerged", regions)
+
+class TestChecksSubmergedAquaticFail(RainWorldTestBase):
+    options = {"checks_submerged": "only_aquatic", "is_msc_enabled": True}
+
+    def test_check_generation(self):
+        regions = [region.name for region in self.multiworld.get_regions(self.player)]
+        self.assertNotIn("Submerged Superstructure", regions)
+        self.assertNotIn("Shoreline near gate to Submerged", regions)
+
+class TestChecksSubmergedOff(RainWorldTestBase):
+    options = {"checks_submerged": "off", "is_msc_enabled": True, "which_campaign": "Rivulet"}
+
+    def test_check_generation(self):
+        regions = [region.name for region in self.multiworld.get_regions(self.player)]
+        self.assertNotIn("Submerged Superstructure", regions)
+        self.assertNotIn("Shoreline near gate to Submerged", regions)


### PR DESCRIPTION
- Submerged generation can now be configured to require the Aquatic Perk to be present
- Submerged difficulty option enhanced to allow requiring the Aquatic Perk
- Added the swim down towards the Submerged gate as "part of Submerged" in regard to check generation
- Rivulet's last Wanderer pip now removed if Submerged is not generated (Closes #230)

Tested via new unit tests as well as fuzzing. When submerged is not to be generated, the region is now excluded in its entirety instead of just the checks being removed. This was necessary due to the addition of the subregion in SL making MS logically inaccessible
