### PR TITLE
Modify story victory conditions to more accurately reflect in-game requirements

### DIFF
--- a/worlds/rain_world/docs/settings_en.md
+++ b/worlds/rain_world/docs/settings_en.md
@@ -32,16 +32,17 @@ Dark areas include:
 The default victory condition, ascension, logically requires raising max karma to 10
 (which requires 8 karma items), accessing Subterranean (or, for Saint, Rubicon),
 and The Glow (unless `Glow required for dark places` is disabled).
-The alternate victory condition varies by slugcat, and is only applicable if MSC is enabled.
+The story victory condition varies by slugcat, and is only applicable if MSC is enabled.
 Each victory condition requires certain items that are placed into the item pool,
 as well as certain additional actions that must be taken to actually reach the ending:
 
 | Slugcat          | Items                                                                                             | Actions                                                                                          |
 |------------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
 | Monk or Survivor |                                                                                                   | - Reach Journey's End (Outer Expanse)                                                            |
-| Gourmand         | - Mark of Communication                                                                           | - Meet Five Pebbles to unlock the OE gate<br/>- Reach Journey's End (Outer Expanse)              |
+| Hunter           | - Slag Key                                                                                        | - Bring the slag key (green neuron) to Looks to the Moon in Shoreline                            |
+| Gourmand         | - Mark of Communication                                                                           | - Reach Journey's End (Outer Expanse)                                                            |
 | Artificer        | - Mark of Communication<br/>- Citizen ID drone                                                    | - Kill the chieftain scavenger in Metropolis                                                     |
 | Rivulet          | - Increased cycle duration (unless **Late Submerged** setting is disabled)<br/>- Rarefaction cell | - Install the rarefaction cell in Submerged Superstructure<br/>- Reunite with Looks the the Moon |
-| Spearmaster      | - Mark of Communication<br/>- Spearmaster's pearl<br/>- Moon's message                            | - Deliver the pearl to Communications Array                                                      |
+| Spearmaster      | - Spearmaster's pearl<br/>- Moon's message                                                        | - Deliver the pearl to Communications Array                                                      |
 
-Hunter, Saint, and Sofanthiel do not have an alternate victory condition.
+Saint and Sofanthiel do not have a story victory condition.

--- a/worlds/rain_world/events/victory.py
+++ b/worlds/rain_world/events/victory.py
@@ -54,22 +54,15 @@ def generate(options: RainWorldOptions) -> list[EventData]:
             VictoryEvent("Old Friend", "Shoreline", Simple("Install rarefaction cell"))
         ]
 
-    ret = [EventData("MeetFP", "MeetFP", "Five Pebbles above puppet")]
-
     if options.starting_scug == "Gourmand":
-        ret.append(VictoryEvent("Migration", "Outer Expanse", Simple(["The Mark", "MeetFP"])))
+        return [VictoryEvent("Migration", "Outer Expanse")]
 
     if options.starting_scug == "Artificer":
-        ret.append(VictoryEvent("Closure", "Metropolis", Simple(["The Mark", "MeetFP"])))
+        return [VictoryEvent("Closure", "Metropolis")]
 
     if options.starting_scug == "Spear":
-        ret += [
-            EventData("MeetLttM", "MeetLttM", "Looks to the Moon"),
-            VictoryEvent("Messenger", "Sky Islands", Simple(
-                ["The Mark", "MeetFP", "MeetLttM", "Moon's Final Message", "Spearmaster's Pearl"]
-            ))
-        ]
+        return [VictoryEvent("Messenger", "Sky Islands", Simple(["Moon's Final Message", "Spearmaster's Pearl"]))]
 
-    return ret
+    return []
 
 

--- a/worlds/rain_world/options.py
+++ b/worlds/rain_world/options.py
@@ -131,15 +131,14 @@ class WhichVictoryCondition(Choice):
 
     **Hunter**: Use the green neuron on Looks to the Moon in Shoreline.
 
-    **Gourmand**: Receive the Mark and reach Journey's End in Outer Expanse.
+    **Gourmand**: Receive the Mark in order to reach Outer Expanse, and subsequently reach Journey's End.
 
-    **Artificer**: Receive the Mark and kill the Chieftain in Metropolis.
+    **Artificer**: Receive the Mark and the Citizen ID drone in order to reach Metropolis and kill the Chieftain Scavenger.
 
     **Rivulet**: Receive the Rarefaction Cell and deliver it to Submerged Superstructure,
     then meet Looks to the Moon.
 
-    **Spearmaster**: Receive the Mark, the SM pearl, and Moon's message,
-    then deliver it to Communications Array in Sky Islands.
+    **Spearmaster**: Receive the SM pearl and Moon's message, then deliver it to Communications Array in Sky Islands.
     """
     display_name = "Victory condition"
     option_ascension = 0


### PR DESCRIPTION
Primarily, Spearmaster goal condition changed to only require the pearl and LttM's message (Closes #237).

Gourmand and Artificer also changed, they do not actually have to meet Five Pebbles directly in order to pass through the gate, as having the Mark is the flag checked by the game. The Mark is also not needed for the victory event itself, as that requirement is already handled by the respective gates into the endgame regions.
