### PR TITLE
Add Watcher filler items

### DIFF
--- a/worlds/rain_world/items.py
+++ b/worlds/rain_world/items.py
@@ -123,6 +123,7 @@ all_items: Dict[str, RainWorldItemData] = {
     "Gooieduck": FillerItemData("Gooieduck", "Object-GooieDuck", 249 + offset, ["MSC"]),
     "Dandelion Peach": FillerItemData("Dandelion Peach", "Object-DandelionPeach", 250 + offset, ["MSC"]),
     "Rot Fruit": FillerItemData("Rot Fruit", "Object-RotFruit", 251 + offset, ["Watcher"]),
+    "Fire Sprite Larva": FillerItemData("Fire Sprite Larva", "Object-FireSpriteLarva", 252 + offset, ["Watcher"]),
 
     #################################################################
     # FILLER - OTHER

--- a/worlds/rain_world/items.py
+++ b/worlds/rain_world/items.py
@@ -106,6 +106,8 @@ all_items: Dict[str, RainWorldItemData] = {
     "Cherrybomb": FillerItemData("Cherrybomb", "Object-FirecrackerPlant", 207 + offset),
     "Singularity Bomb": FillerItemData("Singularity Bomb", "Object-SingularityBomb", 208 + offset, ["MSC"]),
     "Lilypuck": FillerItemData("Lilypuck", "Object-LillyPuck", 209 + offset, ["MSC"]),
+    "Poison Spear": FillerItemData("Poison Spear", "Object-PoisonSpear", 210 + offset, ["Watcher"]),
+    "Boomerang": FillerItemData("Boomerang", "Object-Boomerang", 211 + offset, ["Watcher"]),
 
     #################################################################
     # FILLER - FOOD
@@ -120,6 +122,7 @@ all_items: Dict[str, RainWorldItemData] = {
     "Seed": FillerItemData("Seed", "Object-Seed", 248 + offset, ["MSC"]),
     "Gooieduck": FillerItemData("Gooieduck", "Object-GooieDuck", 249 + offset, ["MSC"]),
     "Dandelion Peach": FillerItemData("Dandelion Peach", "Object-DandelionPeach", 250 + offset, ["MSC"]),
+    "Rot Fruit": FillerItemData("Rot Fruit", "Object-RotFruit", 251 + offset, ["Watcher"]),
 
     #################################################################
     # FILLER - OTHER
@@ -129,6 +132,7 @@ all_items: Dict[str, RainWorldItemData] = {
     "Karma Flower": FillerItemData("Karma Flower", "Object-KarmaFlower", 273 + offset),
     "Vulture Mask": FillerItemData("Vulture Mask", "Object-VultureMask", 274 + offset),
     "Joke Rifle": FillerItemData("Joke Rifle", "Object-JokeRifle", 275 + offset, ["MSC"]),
+    "Graffiti Bomb": FillerItemData("Graffiti Bomb", "Object-GraffitiBomb", 276 + offset, ["Watcher"]),
 
     #################################################################
     # FILLER - NON-CREATURE TRAPS

--- a/worlds/rain_world/options.py
+++ b/worlds/rain_world/options.py
@@ -808,6 +808,30 @@ class WtJokeRifle(WtGeneric):
     item_name = "Joke Rifle"
     default = 1
 
+class WtBoomerang(WtGeneric):
+    """The relative weight of boomerangs in the non-trap filler item pool."""
+    display_name = "Boomerang (Watcher)"
+    item_name = "Boomerang"
+    default = 20
+
+class WtPoisonSpear(WtGeneric):
+    """The relative weight of poison spears in the non-trap filler item pool."""
+    display_name = "Poison Spear (Watcher)"
+    item_name = "Poison Spear"
+    default = 15
+
+class WtGraffitiBomb(WtGeneric):
+    """The relative weight of graffiti bombs in the non-trap filler item pool."""
+    display_name = "Graffiti Bomb (Watcher)"
+    item_name = "Graffiti Bomb"
+    default = 20
+
+class WtRotFruit(WtGeneric):
+    """The relative weight of rot fruits in the non-trap filler item pool."""
+    display_name = "Rot Fruit (Watcher)"
+    item_name = "Rot Fruit"
+    default = 0
+
 
 #################################################################
 # TRAP SETTINGS
@@ -1006,6 +1030,9 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
     wt_electric_spears: WtElectricSpear
     wt_singularity_bombs: WtSingularityBomb
     wt_joke_rifles: WtJokeRifle
+    wt_boomerangs: WtBoomerang
+    wt_poison_spears: WtPoisonSpear
+    wt_graffiti_bombs: WtGraffitiBomb
 
     wt_fruit: WtFruit
     wt_bubblefruit: WtBubbleFruit
@@ -1016,13 +1043,16 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
     wt_karma_flowers: WtKarmaFlower
     wt_fireeggs: WtFireEgg
     wt_glowweed: WtGlowWeed
+    wt_rot_fruit: WtRotFruit
 
     group_filler = [
         WtRock, WtSpear, WtExplosiveSpear, WtGrenade, WtFlashbang, WtSporePuff, WtCherrybomb, WtBubbleWeed, WtLantern,
         WtVultureMask, WtFruit, WtBubbleFruit, WtEggbugEgg, WtJellyfish, WtMushroom, WtSlimeMold, WtKarmaFlower,
 
         WtLillyPuck, WtDandelionPeach, WtElectricSpear, WtSingularityBomb, WtJokeRifle,
-        WtFireEgg, WtGlowWeed
+        WtFireEgg, WtGlowWeed,
+
+        WtBoomerang, WtPoisonSpear, WtGraffitiBomb, WtRotFruit
     ]
 
     #################################################################
@@ -1149,9 +1179,16 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
             self.wt_eggbugeggs, self.wt_jellyfish, self.wt_mushrooms, self.wt_slimemold,
             self.wt_fireeggs, self.wt_glowweed, self.wt_electric_spears, self.wt_singularity_bombs,
             self.wt_lanterns, self.wt_karma_flowers, self.wt_vulture_masks, self.wt_joke_rifles,
+            self.wt_boomerangs, self.wt_poison_spears, self.wt_graffiti_bombs, self.wt_rot_fruit,
         ]}
         if not self.msc_enabled:
-            for key in ("Lilypuck", "Dandelion Peach", "Fire Egg", "Glow Weed", "Electric Spear", "Singularity Bomb", "Joke Rifle"):
+            for key in ("Fire Egg", "Electric Spear", "Joke Rifle"):
+                ret[f"{key}"] = 0
+        if not self.is_watcher_enabled:
+            for key in ("Boomerang", "Poison Spear", "Graffiti Bomb", "Rot Fruit"):
+                ret[f"{key}"] = 0
+        if not self.msc_enabled and not self.is_watcher_enabled:
+            for key in ("Lilypuck", "Dandelion Peach", "Glow Weed", "Singularity Bomb"):
                 ret[f"{key}"] = 0
 
         return ret

--- a/worlds/rain_world/options.py
+++ b/worlds/rain_world/options.py
@@ -1085,6 +1085,9 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
     def msc_enabled(self) -> bool: return self.is_msc_enabled == 1
 
     @property
+    def any_dlc_enabled(self) -> bool: return self.is_msc_enabled == 1 or self.is_watcher_enabled == 1
+
+    @property
     def dlcstate(self) -> str:
         if self.is_msc_enabled:
             if self.is_watcher_enabled:
@@ -1187,7 +1190,7 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
         if not self.is_watcher_enabled:
             for key in ("Boomerang", "Poison Spear", "Graffiti Bomb", "Rot Fruit"):
                 ret[f"{key}"] = 0
-        if not self.msc_enabled and not self.is_watcher_enabled:
+        if not self.any_dlc_enabled:
             for key in ("Lilypuck", "Dandelion Peach", "Glow Weed", "Singularity Bomb"):
                 ret[f"{key}"] = 0
 

--- a/worlds/rain_world/options.py
+++ b/worlds/rain_world/options.py
@@ -832,6 +832,11 @@ class WtRotFruit(WtGeneric):
     item_name = "Rot Fruit"
     default = 0
 
+class WtFireSpriteLarva(WtGeneric):
+    """The relative weight of fire sprite larvae in the non-trap filler item pool."""
+    display_name = "Fire Sprite Larva (Watcher)"
+    item_name = "Fire Sprite Larva"
+    default = 30
 
 #################################################################
 # TRAP SETTINGS
@@ -1044,6 +1049,7 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
     wt_fireeggs: WtFireEgg
     wt_glowweed: WtGlowWeed
     wt_rot_fruit: WtRotFruit
+    wt_fire_sprite_larva: WtFireSpriteLarva
 
     group_filler = [
         WtRock, WtSpear, WtExplosiveSpear, WtGrenade, WtFlashbang, WtSporePuff, WtCherrybomb, WtBubbleWeed, WtLantern,
@@ -1052,7 +1058,7 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
         WtLillyPuck, WtDandelionPeach, WtElectricSpear, WtSingularityBomb, WtJokeRifle,
         WtFireEgg, WtGlowWeed,
 
-        WtBoomerang, WtPoisonSpear, WtGraffitiBomb, WtRotFruit
+        WtBoomerang, WtPoisonSpear, WtGraffitiBomb, WtRotFruit, WtFireSpriteLarva
     ]
 
     #################################################################
@@ -1183,12 +1189,13 @@ class RainWorldOptions(PerGameCommonOptions, DeathLinkMixin):
             self.wt_fireeggs, self.wt_glowweed, self.wt_electric_spears, self.wt_singularity_bombs,
             self.wt_lanterns, self.wt_karma_flowers, self.wt_vulture_masks, self.wt_joke_rifles,
             self.wt_boomerangs, self.wt_poison_spears, self.wt_graffiti_bombs, self.wt_rot_fruit,
+            self.wt_fire_sprite_larva,
         ]}
         if not self.msc_enabled:
             for key in ("Fire Egg", "Electric Spear", "Joke Rifle"):
                 ret[f"{key}"] = 0
         if not self.is_watcher_enabled:
-            for key in ("Boomerang", "Poison Spear", "Graffiti Bomb", "Rot Fruit"):
+            for key in ("Boomerang", "Poison Spear", "Graffiti Bomb", "Rot Fruit", "Fire Sprite Larva"):
                 ret[f"{key}"] = 0
         if not self.any_dlc_enabled:
             for key in ("Lilypuck", "Dandelion Peach", "Glow Weed", "Singularity Bomb"):


### PR DESCRIPTION
Adds Boomerangs, Poison Spears, Graffiti bombs, and Rot fruits to the filler item pool. Allows certain items to be added to pool if either DLC is enabled, to match in-game.


