### PR TITLE
Passage refactor

### DIFF
--- a/worlds/rain_world/__init__.py
+++ b/worlds/rain_world/__init__.py
@@ -159,6 +159,7 @@ class RainWorldWorld(World):
                 **{k: 1 for k, v in portal_keys.items() if (not v.spinning_top or self.options.spinning_top_keys)
                    and ("Daemon" not in v.name or self.options.daemon_keys)},
                 "Dial Warp Ability": 1,
+                "The Mark": 1,
             }
             if (ndwb := self.options.normal_dynamic_warp_behavior).unlockable:
                 pool.update({f"Dynamic: {k}": 1 for k in (normal_regions if ndwb.predetermined else self.warp_pool)})

--- a/worlds/rain_world/docs/checks_en.md
+++ b/worlds/rain_world/docs/checks_en.md
@@ -74,12 +74,12 @@ and also depends on the `Passage progress without Survivor` setting in the playe
 
 There are four passages that may always be earned before The Survivor is earned, regardless of settings:
 
-| Passage           | Eligibility                                 | Requirements                                    |
-|-------------------|---------------------------------------------|-------------------------------------------------|
-| The Martyr        | Any; MSC enabled                            | None                                            |
-| The Mother        | Survivor, Hunter, or Gourmand; MSC enabled  | Access to HI, DS, GW, SH, CC, SI, LF, SB, or VS |
-| The Pilgrim       | Any; MSC enabled                            | Access to all eligible echoes                   |
-| The Survivor      | Any                                         | Max karma at least 5                            |
+| Passage           | Eligibility                                | Requirements                                    |
+|-------------------|--------------------------------------------|-------------------------------------------------|
+| The Martyr        | Any; MSC enabled                           | None                                            |
+| The Mother        | Survivor, Hunter, or Gourmand; MSC enabled | Access to HI, DS, GW, SH, CC, SI, LF, SB, or VS |
+| The Pilgrim       | Not Watcher; MSC enabled                   | Access to all eligible echoes                   |
+| The Survivor      | Any                                        | Max karma at least 5                            |
 
 There are three passages that may be earned before The Survivor,
 but only if the `Passage progress without Survivor` setting is either `enabled` or `bypassed`:
@@ -88,7 +88,7 @@ but only if the `Passage progress without Survivor` setting is either `enabled` 
 |-------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | The Dragon Slayer | Not Saint   | - Vanilla: Access to Blue, Pink, Green, Yellow, Black, and White Lizards<br/>- MSC: Red, Cyan, Strawberry, and Caramel Lizards also count |
 | The Friend        | Any         | Access to one lizard                                                                                                                      |
-| The Wanderer      | Any         | Access to every story region for the given slugcat; each individual pip is also a check                                                   |
+| The Wanderer      | Not Watcher | Access to every story region for the given slugcat; each individual pip is also a check                                                   |
 
 The remaining seven passages require The Survivor unless
 `Passage progress without Survivor` is `bypassed`:
@@ -98,7 +98,7 @@ The remaining seven passages require The Survivor unless
 | The Chieftain | Not Artificer                                           | Access to a Scavenger (or Scavenger Toll if `The Chieftain requires toll` is set)                                                                                                           |
 | The Hunter    | Not Saint                                               | Access to several types of meat (number depends on `The Hunter difficulty` setting)                                                                                                         |
 | The Monk      | Any                                                     | - For Hunter, Artificer, and Spearmaster: Access to SI, LF, SS, or DM<br/>- For other slugcats: Access to several types of non-meat foods (number depends on `The Monk difficulty` setting) |
-| The Nomad     | Any; MSC enabled                                        | Access to several regions (number depends on `The Nomad difficulty` setting)                                                                                                                |  
+| The Nomad     | Not Watcher; MSC enabled                                | Access to several regions (number depends on `The Nomad difficulty` setting)                                                                                                                |  
 | The Outlaw    | Not Saint                                               | Access to several eligible creatures (number depends on `The Outlaw difficulty` setting)                                                                                                    |
 | The Saint     | Any                                                     | - For Hunter, Artificer, and Spearmaster: Access to SI, LF, SS, or DM<br/>- For other slugcats: No requirements                                                                             |
 | The Scholar   | Not Monk unless MSC is enabled; Not Saint or Sofanthiel | - The Mark of Communication<br/>- Access to three colored pearls<br/>- For Monk, Survivor, and Gourmand: access to Looks to the Moon                                                        |

--- a/worlds/rain_world/locations/passages.py
+++ b/worlds/rain_world/locations/passages.py
@@ -1,18 +1,22 @@
 from .classes import Passage, LocationData
 from .. import game_data
+from ..game_data.general import regions_all
 from ..options import RainWorldOptions
-from ..conditions.classes import Condition, Simple, AnyOf, AllOf
+from ..conditions.classes import Condition, Simple, AnyOf, AllOf, ConditionBlank
+
+
+#################################################################
+# SURVIVOR
+def generate_cond_survivor(options: RainWorldOptions) -> Condition:
+    if options.starting_scug == "Watcher":
+        return ConditionBlank
+    return Simple("Karma", 4)
 
 
 #################################################################
 # CHIEFTAIN
 def generate_cond_chieftain(options: RainWorldOptions) -> Condition:
-    return AllOf(
-        (
-            Simple("Toll") if options.difficulty_chieftain else Simple(["Scavenger", "ScavengerElite"], 1)
-        ),
-        Simple([f"Scug-{s}" for s in set(game_data.general.scugs_all) - {"Artificer"}], 1)
-    )
+    return Simple("Toll") if options.difficulty_chieftain else Simple(["Scavenger", "ScavengerElite"], 1)
 
 
 #################################################################
@@ -20,16 +24,8 @@ def generate_cond_chieftain(options: RainWorldOptions) -> Condition:
 def generate_cond_dragonslayer(options: RainWorldOptions) -> Condition:
     if not options.msc_enabled:
         return Simple(game_data.general.dragonslayer_vanilla)
-    if options.difficulty_extreme_threats == 2:
+    if options.difficulty_extreme_threats:
         return Simple(game_data.general.dragonslayer_msc, 6)
-    elif options.difficulty_extreme_threats == 1:
-        return AnyOf(
-            Simple(game_data.general.dragonslayer_msc.difference({"RedLizard"}), 6),
-            AllOf(
-                Simple(game_data.general.dragonslayer_msc, 6),
-                Simple(["Scug-Artificer", "Scug-Spear", "Scug-Inv"], 1)
-            )
-        )
     else:
         return Simple(game_data.general.dragonslayer_msc.difference({"RedLizard"}), 6)
 
@@ -42,20 +38,15 @@ cond_friend = Simple(game_data.general.lizards_any, 1)
 #################################################################
 # HUNTER
 def generate_cond_hunter(options: RainWorldOptions) -> Condition:
-    return AnyOf(
-        AllOf(
-            Simple(["Scug-Red", "Scug-Artificer", "Scug-Spear", "Scug-Gourmand", "Scug-Inv"], 1),
-            Simple([f"Access-{region}" for region in set(game_data.general.regions_all).difference({"SS", "MS"})], 1)
-        ),
-        AllOf(
-            Simple(["Scug-Yellow", "Scug-White", "Scug-Rivulet"], 1),
-            Simple(
-                ["Fly", "SmallNeedleWorm", "SmallCentipede", "Centipede",
-                 "EggBug", "JellyFish", "Hazer", "VultureGrub"],
-                options.difficulty_hunter.value
-            )
+    # Carnivorous slugcats use simple region check
+    if options.starting_scug in ["Red", "Artificer", "Spear", "Gourmand", "Inv"]:
+        return Simple([f"Access-{region}" for region in set(game_data.general.regions_all).difference({"SS", "MS"})], 1)
+    return Simple(
+            ["Fly", "SmallNeedleWorm", "SmallCentipede", "Centipede",
+             "EggBug", "JellyFish", "Hazer", "VultureGrub", "Frog", "Tardigrade",
+             "SandGrubNetwork", "PlacedRats", "Barnacle"],
+            options.difficulty_hunter.value
         )
-    )
 
 
 #################################################################
@@ -71,20 +62,13 @@ def generate_cond_monk(options: RainWorldOptions) -> Condition:
 
 #################################################################
 # MOTHER
-cond_mother = AllOf(
-    Simple("MSC"),
-    Simple([f"Scug-{scug}" for scug in ("White", "Red", "Gourmand")], 1),
-    Simple([f"Access-{region}" for region in game_data.general.slugpup_normal_regions], 1)
-)
+cond_mother = Simple([f"Access-{region}" for region in game_data.general.slugpup_normal_regions], 1)
 
 
 #################################################################
 # NOMAD
 def generate_cond_nomad(options: RainWorldOptions) -> Condition:
-    return AllOf(
-        Simple("MSC"),
-        Simple([f"Access-{region}" for region in game_data.general.regions_all], options.difficulty_nomad.value)
-    )
+    return Simple([f"Access-{region}" for region in game_data.general.regions_all], options.difficulty_nomad.value)
 
 
 #################################################################
@@ -112,17 +96,11 @@ def generate_cond_pilgrim(options: RainWorldOptions) -> Condition:
 
 #################################################################
 # SCHOLAR
-cond_scholar = AnyOf(
-    Simple(["MSC", "Scug-Yellow", "Access-SL", "The Mark"]),  # Monk requires MSC to see colored pearls
-    AllOf(
-        Simple(["Scug-White", "Scug-Gourmand"], 1),
-        Simple(["Access-SL", "The Mark"])
-    ),
-    AllOf(
-        Simple(["Scug-Artificer", "Scug-Spear", "Scug-Red", "Scug-Rivulet"], 1),
-        Simple("The Mark")
-    ),
-)
+def generate_cond_scholar(options: RainWorldOptions) -> Condition:
+    if options.starting_scug in ["Yellow", "White", "Gourmand"]:
+        return Simple(["Access-SL", "The Mark"])
+    return Simple("The Mark")
+
 
 #################################################################
 # WANDERER
@@ -135,19 +113,9 @@ regions_rivulet = game_data.general.story_regions_rivulet
 regions_spearmaster = game_data.general.story_regions_spearmaster
 regions_saint = game_data.general.story_regions_saint
 
-cond_wanderer_vanilla = AllOf(Simple([f"Access-{r}" for r in regions]), Simple("MSC", negative=True))
-cond_wanderer_msc_base = AllOf(
-    Simple([f"Access-{r}" for r in regions_msc] + ["MSC"]),
-    Simple(["Scug-Yellow", "Scug-White", "Scug-Red", "Scug-Inv"], 1)
-)
-cond_wanderer_gourmand = Simple([f"Access-{r}" for r in regions_gourmand] + ["MSC", "Scug-Gourmand"])
-cond_wanderer_artificer = Simple([f"Access-{r}" for r in regions_artificer] + ["MSC", "Scug-Artificer"])
-cond_wanderer_rivulet = Simple([f"Access-{r}" for r in regions_rivulet] + ["MSC", "Scug-Rivulet"])
-cond_wanderer_spearmaster = Simple([f"Access-{r}" for r in regions_spearmaster] + ["MSC", "Scug-Spear"])
-cond_wanderer_saint = Simple([f"Access-{r}" for r in regions_saint] + ["MSC", "Scug-Saint"])
 
-cond_wanderer = AnyOf(cond_wanderer_vanilla, cond_wanderer_msc_base, cond_wanderer_gourmand,
-                      cond_wanderer_artificer, cond_wanderer_rivulet, cond_wanderer_spearmaster, cond_wanderer_saint)
+def generate_cond_wanderer(options: RainWorldOptions) -> Condition:
+    return Simple([f"Access-{r}" for r in wanderer_regions(options.starting_scug, options.msc_enabled)])
 
 
 def wanderer_regions(scug: str, msc: bool) -> set[str]:
@@ -163,19 +131,8 @@ def wanderer_regions(scug: str, msc: bool) -> set[str]:
 
 
 def wanderer_pip_factory(count: int) -> Condition:
-    return AnyOf(
-        AllOf(Simple("MSC", negative=True), Simple([f"Access-{r}" for r in regions], count)),
-        AllOf(
-            Simple("MSC"),
-            Simple(["Scug-Yellow", "Scug-White", "Scug-Red", "Scug-Inv"], 1),
-            Simple([f"Access-{r}" for r in regions_msc], count)
-        ),
-        AllOf(Simple("Scug-Gourmand"), Simple([f"Access-{r}" for r in regions_gourmand], count)),
-        AllOf(Simple("Scug-Artificer"), Simple([f"Access-{r}" for r in regions_artificer], count)),
-        AllOf(Simple("Scug-Rivulet"), Simple([f"Access-{r}" for r in regions_rivulet], count)),
-        AllOf(Simple("Scug-Spear"), Simple([f"Access-{r}" for r in regions_spearmaster], count)),
-        AllOf(Simple("Scug-Saint"), Simple([f"Access-{r}" for r in regions_saint], count)),
-    )
+    # We just need access to some number of regions from this list, it's not necessary to filter by gamestate
+    return Simple([f"Access-{r}" for r in regions_all], count)
 
 
 #################################################################
@@ -184,19 +141,19 @@ locations: dict[str, LocationData] = {
     "Martyr": Passage("Martyr", "Early Passages", 5000),
     "Mother": Passage("Mother", "Early Passages", 5001, cond_mother),
     "Pilgrim": Passage("Pilgrim", "Early Passages", 5002, access_condition_generator=generate_cond_pilgrim),
-    "Survivor": Passage("Survivor", "Early Passages", 5003, AnyOf(Simple("Karma", 4), Simple("Scug-Watcher"))),
+    "Survivor": Passage("Survivor", "Early Passages", 5003, access_condition_generator=generate_cond_survivor),
 
     "DragonSlayer": Passage("DragonSlayer", "PPwS Passages", 5020,
                             access_condition_generator=generate_cond_dragonslayer),
     "Friend": Passage("Friend", "PPwS Passages", 5021, cond_friend),
-    "Traveller": Passage("Traveller", "PPwS Passages", 5022, cond_wanderer),
+    "Traveller": Passage("Traveller", "PPwS Passages", 5022, access_condition_generator=generate_cond_wanderer),
 
     "Chieftain": Passage("Chieftain", "Late Passages", 5040, access_condition_generator=generate_cond_chieftain),
     "Hunter": Passage("Hunter", "Late Passages", 5041, access_condition_generator=generate_cond_hunter),
     "Monk": Passage("Monk", "Late Passages", 5042, access_condition_generator=generate_cond_monk),
     "Outlaw": Passage("Outlaw", "Late Passages", 5043, access_condition_generator=generate_cond_outlaw),
     "Saint": Passage("Saint", "Late Passages", 5044, access_condition_generator=generate_cond_monk),
-    "Scholar": Passage("Scholar", "Late Passages", 5045, cond_scholar),
+    "Scholar": Passage("Scholar", "Late Passages", 5045, access_condition_generator=generate_cond_scholar),
     "Nomad": Passage("Nomad", "Late Passages", 5046, access_condition_generator=generate_cond_nomad),
     **{
         f"Wanderer-{i}": LocationData(
@@ -210,9 +167,6 @@ locations: dict[str, LocationData] = {
 def generate(options: RainWorldOptions) -> list[LocationData]:
     keys = ["Survivor", "Friend", "Monk", "Saint"]
 
-    if options.starting_scug == "Watcher":
-        return [locations["Survivor"]] # TODO Passages
-
     if options.starting_scug != "Artificer":
         keys.append("Chieftain")
 
@@ -222,15 +176,18 @@ def generate(options: RainWorldOptions) -> list[LocationData]:
             keys.append("Scholar")
 
     if options.msc_enabled:
-        keys += ["Martyr", "Pilgrim", "Nomad"]
+        keys.append("Martyr")
+        if options.starting_scug != "Watcher":
+            keys += ["Pilgrim", "Nomad"]
         if options.starting_scug in ["White", "Red", "Gourmand"]:
             keys.append("Mother")
 
-    # Riv can't get last pip if Submerged inaccessible
-    if options.starting_scug != "Rivulet" or options.submerged_should_populate:
-        keys += [f"Wanderer-{i + 1}" for i in range(len(wanderer_regions(options.starting_scug, options.msc_enabled)))]
-        keys.append("Traveller")
-    else:
-        keys += [f"Wanderer-{i + 1}" for i in range(len(wanderer_regions(options.starting_scug, options.msc_enabled)) - 1)]
+    if options.starting_scug != "Watcher":
+        # Riv can't get last pip if Submerged inaccessible
+        if options.starting_scug != "Rivulet" or options.submerged_should_populate:
+            keys += [f"Wanderer-{i + 1}" for i in range(len(wanderer_regions(options.starting_scug, options.msc_enabled)))]
+            keys.append("Traveller")
+        else:
+            keys += [f"Wanderer-{i + 1}" for i in range(len(wanderer_regions(options.starting_scug, options.msc_enabled)) - 1)]
 
     return [locations[key] for key in keys]


### PR DESCRIPTION
Refactors passages to no longer use the `Scug-` and `MSC` event items. Much of the logic has been simplified, mostly by cutting unnecessary conditions checking for irrelevant slugcats.

Also adds Watcher passages.
- Survivor is a blank condition for Watcher.
- Added edible Watcher creatures to The Hunter condition.
- Added The Mark to the item pool to make The Scholar possible.
- Watcher cannot get Nomad, Pilgrim, or Wanderer.